### PR TITLE
DEVOPS-3362 Quantity arithmetic library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/spf13/viper v1.13.0
 	github.com/stretchr/testify v1.8.0
 	go.uber.org/zap v1.23.0
+	gopkg.in/inf.v0 v0.9.1
 	k8s.io/apimachinery v0.25.0
 	k8s.io/cli-runtime v0.25.0
 	k8s.io/client-go v0.25.0
@@ -82,7 +83,6 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
-	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/quantity/quantity.go
+++ b/internal/quantity/quantity.go
@@ -1,0 +1,65 @@
+package quantity
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// Add returns the result of x+y.
+// If true is returned, the operation overflowed and the result will be equal to x.
+func Add(x resource.Quantity, y resource.Quantity) (result resource.Quantity, overflow bool) {
+	overflow = false
+	result = x.DeepCopy()
+	result.Add(y)
+
+	if !y.IsZero() && result.Cmp(x) == 0 {
+		// TODO add to PR comment it seems overflow is "possible"
+		// https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go#L573
+		// however, like in the _test.go, I don't think it's possible for us to cause it
+		overflow = true
+	}
+
+	return
+}
+
+// Add returns the result of x-y.
+// If true is returned, the operation overflowed and the result will be equal to x.
+func Sub(x resource.Quantity, y resource.Quantity) (result resource.Quantity, overflow bool) {
+	overflow = false
+	result = x.DeepCopy()
+	result.Sub(y)
+
+	if !y.IsZero() && result.Cmp(x) == 0 {
+		overflow = true
+	}
+
+	return
+}
+
+func Mul(x resource.Quantity, y resource.Quantity) resource.Quantity {
+	result := resource.Quantity{}
+	result.Format = x.Format
+
+	result.AsDec().Mul(x.AsDec(), y.AsDec())
+	return result
+}
+
+func MulFloat64(x resource.Quantity, y float64) (resource.Quantity, error) {
+	yQuantity, err := resource.ParseQuantity(fmt.Sprintf("%v", y))
+	if err != nil {
+		return x, err
+	}
+
+	return Mul(x, yQuantity), nil
+}
+
+func DivFloat64(x resource.Quantity, y float64) (resource.Quantity, error) {
+	yInverse := 1 / y
+	yQuantity, err := resource.ParseQuantity(fmt.Sprintf("%v", yInverse))
+	if err != nil {
+		return x, err
+	}
+
+	return Mul(x, yQuantity), nil
+}

--- a/internal/quantity/quantity.go
+++ b/internal/quantity/quantity.go
@@ -3,6 +3,7 @@ package quantity
 import (
 	"fmt"
 
+	"gopkg.in/inf.v0"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -35,7 +36,19 @@ func MulFloat64(x resource.Quantity, y float64) (resource.Quantity, error) {
 	return Mul(x, yQuantity), nil
 }
 
+func Div(x resource.Quantity, y resource.Quantity) resource.Quantity {
+	result := resource.Quantity{}
+	result.Format = x.Format
+
+	result.AsDec().QuoRound(x.AsDec(), y.AsDec(), 0, inf.RoundUp)
+	return result
+}
+
 func DivFloat64(x resource.Quantity, y float64) (resource.Quantity, error) {
-	yInverse := 1 / y
-	return MulFloat64(x, yInverse)
+	yQuantity, err := resource.ParseQuantity(fmt.Sprintf("%v", y))
+	if err != nil {
+		return x, err
+	}
+
+	return Div(x, yQuantity), nil
 }

--- a/internal/quantity/quantity.go
+++ b/internal/quantity/quantity.go
@@ -6,35 +6,16 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-// Add returns the result of x+y.
-// If true is returned, the operation overflowed and the result will be equal to x.
-func Add(x resource.Quantity, y resource.Quantity) (result resource.Quantity, overflow bool) {
-	overflow = false
-	result = x.DeepCopy()
+func Add(x resource.Quantity, y resource.Quantity) resource.Quantity {
+	result := x.DeepCopy()
 	result.Add(y)
-
-	if !y.IsZero() && result.Cmp(x) == 0 {
-		// TODO add to PR comment it seems overflow is "possible"
-		// https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go#L573
-		// however, like in the _test.go, I don't think it's possible for us to cause it
-		overflow = true
-	}
-
-	return
+	return result
 }
 
-// Add returns the result of x-y.
-// If true is returned, the operation overflowed and the result will be equal to x.
-func Sub(x resource.Quantity, y resource.Quantity) (result resource.Quantity, overflow bool) {
-	overflow = false
-	result = x.DeepCopy()
+func Sub(x resource.Quantity, y resource.Quantity) resource.Quantity {
+	result := x.DeepCopy()
 	result.Sub(y)
-
-	if !y.IsZero() && result.Cmp(x) == 0 {
-		overflow = true
-	}
-
-	return
+	return result
 }
 
 func Mul(x resource.Quantity, y resource.Quantity) resource.Quantity {
@@ -56,10 +37,5 @@ func MulFloat64(x resource.Quantity, y float64) (resource.Quantity, error) {
 
 func DivFloat64(x resource.Quantity, y float64) (resource.Quantity, error) {
 	yInverse := 1 / y
-	yQuantity, err := resource.ParseQuantity(fmt.Sprintf("%v", yInverse))
-	if err != nil {
-		return x, err
-	}
-
-	return Mul(x, yQuantity), nil
+	return MulFloat64(x, yInverse)
 }

--- a/internal/quantity/quantity_test.go
+++ b/internal/quantity/quantity_test.go
@@ -1,0 +1,198 @@
+package quantity
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/inf.v0"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestAdd(t *testing.T) {
+	t.Parallel()
+
+	// big.Int can represent numbers greater than max(int64)
+	bigInt := big.NewInt(0).SetUint64(18446744073709551614)
+
+	tests := []struct {
+		inputA       resource.Quantity
+		inputB       resource.Quantity
+		want         resource.Quantity
+		wantOverflow bool
+	}{
+		{
+			inputA:       *resource.NewQuantity(15000, resource.BinarySI),
+			inputB:       *resource.NewQuantity(17000, resource.BinarySI),
+			want:         *resource.NewQuantity(32000, resource.BinarySI),
+			wantOverflow: false,
+		},
+		{
+			// binary + decimal = binary
+			inputA:       *resource.NewQuantity(11, resource.BinarySI),
+			inputB:       *resource.NewQuantity(34, resource.DecimalSI),
+			want:         *resource.NewQuantity(45, resource.BinarySI),
+			wantOverflow: false,
+		},
+		{
+			// 1200 + 0.01 = 1200.01
+			// inf.Scale is negated, -2 means *100, 2 means *0.01
+			inputA:       *resource.NewDecimalQuantity(*inf.NewDec(12, -2), resource.DecimalSI),
+			inputB:       *resource.NewDecimalQuantity(*inf.NewDec(1, 2), resource.DecimalSI),
+			want:         *resource.NewDecimalQuantity(*inf.NewDec(120001, 2), resource.DecimalSI),
+			wantOverflow: false,
+		},
+		{
+			// -10 + 0.00028 = -9.99972
+			inputA:       *resource.NewScaledQuantity(-1, 1),
+			inputB:       *resource.NewScaledQuantity(28, -5),
+			want:         *resource.NewScaledQuantity(-999972, -5),
+			wantOverflow: false,
+		},
+		{
+			// overflow testing, max int64 is 9.223372036854775807x10^18
+			// use 123400*10^18 + 987600*10^18
+			inputA:       *resource.NewScaledQuantity(123400, resource.Exa),
+			inputB:       *resource.NewScaledQuantity(987600, resource.Exa),
+			want:         *resource.NewScaledQuantity(1111000, resource.Exa),
+			wantOverflow: false,
+		},
+		{
+			// demonstrates for practical uses, cannot overflow
+			// [max(int64) x10^max(int32)] + [max(int64) x10^max(int32)]
+			inputA:       *resource.NewScaledQuantity(9223372036854775807, 2147483647),
+			inputB:       *resource.NewScaledQuantity(9223372036854775807, 2147483647),
+			want:         *resource.NewDecimalQuantity(*inf.NewDecBig(bigInt, -2147483647), resource.DecimalSI),
+			wantOverflow: false,
+		},
+	}
+
+	for _, test := range tests {
+		result, overflow := Add(test.inputA, test.inputB)
+
+		assert.Equal(t, test.want, result)
+		assert.Equal(t, test.wantOverflow, overflow)
+	}
+}
+
+func TestSub(t *testing.T) {
+	t.Parallel()
+
+	// big.Int can represent numbers smaller than min(int64)
+	bigInt := big.NewInt(0).SetUint64(18446744073709551615)
+	bigInt = bigInt.Neg(bigInt)
+
+	tests := []struct {
+		inputA       resource.Quantity
+		inputB       resource.Quantity
+		want         resource.Quantity
+		wantOverflow bool
+	}{
+		{
+			inputA:       resource.MustParse("31Gi"),
+			inputB:       resource.MustParse("27.2Gi"),
+			want:         resource.MustParse("3.8Gi"),
+			wantOverflow: false,
+		},
+		{
+			// binary - decimal = binary
+			inputA:       resource.MustParse("55Ki"),
+			inputB:       resource.MustParse("5000"),
+			want:         *resource.NewQuantity(51320, resource.BinarySI),
+			wantOverflow: false,
+		},
+		{
+			// 1200 - 0.01 = 1199.99
+			// inf.Scale is negated, -2 means *100, 2 mean *0.01
+			inputA:       *resource.NewDecimalQuantity(*inf.NewDec(12, -2), resource.DecimalSI),
+			inputB:       *resource.NewDecimalQuantity(*inf.NewDec(1, 2), resource.DecimalSI),
+			want:         *resource.NewDecimalQuantity(*inf.NewDec(119999, 2), resource.DecimalSI),
+			wantOverflow: false,
+		},
+		{
+			// 10 - 10.00028 = -0.00028
+			inputA:       *resource.NewScaledQuantity(1, 1),
+			inputB:       *resource.NewScaledQuantity(1000028, -5),
+			want:         *resource.NewScaledQuantity(-28, -5),
+			wantOverflow: false,
+		},
+		{
+			// shouldn't overflow, min int64 is -9.223372036854775808x10^18
+			// use 123400*10^18 - 987600*10^18
+			inputA:       *resource.NewScaledQuantity(123400, resource.Exa),
+			inputB:       *resource.NewScaledQuantity(987600, resource.Exa),
+			want:         *resource.NewScaledQuantity(-864200, resource.Exa),
+			wantOverflow: false,
+		},
+		{
+			// demonstrates for practical uses, cannot overflow
+			// [min(int64) x10^max(int32)] - [max(int64) x10^max(int32)]
+			inputA:       *resource.NewScaledQuantity(-9223372036854775808, 2147483647),
+			inputB:       *resource.NewScaledQuantity(9223372036854775807, 2147483647),
+			want:         *resource.NewDecimalQuantity(*inf.NewDecBig(bigInt, -2147483647), resource.DecimalSI),
+			wantOverflow: false,
+		},
+	}
+
+	for _, test := range tests {
+		result, overflow := Sub(test.inputA, test.inputB)
+
+		assert.Equal(t, test.want, result)
+		assert.Equal(t, test.wantOverflow, overflow)
+	}
+}
+
+func TestMulFloat64(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		inputA    resource.Quantity
+		inputB    float64
+		want      resource.Quantity
+		wantError error
+	}{
+		{
+			inputA:    resource.MustParse("31Gi"),
+			inputB:    2.525873,
+			want:      *resource.NewDecimalQuantity(*inf.NewDec(84076199948582912, 6), resource.BinarySI),
+			wantError: nil,
+		},
+	}
+
+	for _, test := range tests {
+		result, err := MulFloat64(test.inputA, test.inputB)
+
+		assert.Equal(t, test.want, result)
+		assert.Equal(t, test.wantError, err)
+	}
+}
+
+func TestDivFloat64(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		inputA            resource.Quantity
+		inputB            float64
+		roundingPrecision int32
+		want              resource.Quantity
+		wantError         error
+	}{
+		{
+			inputA:            resource.MustParse("31Gi"),
+			inputB:            2.525873,
+			roundingPrecision: 3, // KiB precision
+			want:              *resource.NewDecimalQuantity(*inf.NewDec(13178016687, 0), resource.BinarySI),
+			wantError:         nil,
+		},
+	}
+
+	for _, test := range tests {
+		result, err := DivFloat64(test.inputA, test.inputB)
+
+		result.RoundUp(resource.Scale(test.roundingPrecision))
+		test.want.RoundUp(resource.Scale(test.roundingPrecision))
+
+		assert.Equal(t, test.want, result)
+		assert.Equal(t, test.wantError, err)
+	}
+}

--- a/internal/quantity/quantity_test.go
+++ b/internal/quantity/quantity_test.go
@@ -19,17 +19,20 @@ func TestAdd(t *testing.T) {
 		inputA resource.Quantity
 		inputB resource.Quantity
 		want   resource.Quantity
+		msg    string
 	}{
 		{
 			inputA: resource.MustParse("31.123456Gi"),
 			inputB: resource.MustParse("27.654321Gi"),
 			want:   resource.MustParse("58.777777Gi"),
+			msg:    "Add(parsed BinarySI, parsed BinarySI)",
 		},
 		{
 			// binary + decimal = binary
 			inputA: *resource.NewQuantity(11, resource.BinarySI),
 			inputB: *resource.NewQuantity(34, resource.DecimalSI),
 			want:   *resource.NewQuantity(45, resource.BinarySI),
+			msg:    "Add(BinarySI, DecimalSI)",
 		},
 		{
 			// 1200 + 0.01 = 1200.01
@@ -37,24 +40,26 @@ func TestAdd(t *testing.T) {
 			inputA: *resource.NewDecimalQuantity(*inf.NewDec(12, -2), resource.DecimalSI),
 			inputB: *resource.NewDecimalQuantity(*inf.NewDec(1, 2), resource.DecimalSI),
 			want:   *resource.NewDecimalQuantity(*inf.NewDec(120001, 2), resource.DecimalSI),
+			msg:    "Add(DecimalSI, DecimalSI with decimal digits)",
 		},
 		{
 			// -10 + 0.00028 = -9.99972
 			inputA: *resource.NewScaledQuantity(-1, 1),
 			inputB: *resource.NewScaledQuantity(28, -5),
 			want:   *resource.NewScaledQuantity(-999972, -5),
+			msg:    "Add(negative DecimalSI, DecimalSI with decimal digits)",
 		},
 		{
-			// demonstrates for practical uses, cannot overflow
 			// [max(int64) x10^max(int32)] + [max(int64) x10^max(int32)]
 			inputA: *resource.NewScaledQuantity(9223372036854775807, 2147483647),
 			inputB: *resource.NewScaledQuantity(9223372036854775807, 2147483647),
 			want:   *resource.NewDecimalQuantity(*inf.NewDecBig(bigInt, -2147483647), resource.DecimalSI),
+			msg:    "Add(overflow testing)",
 		},
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.want, Add(test.inputA, test.inputB))
+		assert.Equal(t, test.want, Add(test.inputA, test.inputB), test.msg)
 	}
 }
 
@@ -69,17 +74,20 @@ func TestSub(t *testing.T) {
 		inputA resource.Quantity
 		inputB resource.Quantity
 		want   resource.Quantity
+		msg    string
 	}{
 		{
 			inputA: resource.MustParse("31Gi"),
 			inputB: resource.MustParse("27.2Gi"),
 			want:   resource.MustParse("3.8Gi"),
+			msg:    "Sub(parsed BinarySI, parsed BinarySI)",
 		},
 		{
 			// binary - decimal = binary
 			inputA: resource.MustParse("55Ki"),
 			inputB: resource.MustParse("5000"),
 			want:   *resource.NewQuantity(51320, resource.BinarySI),
+			msg:    "Sub(BinarySI, DecimalSI)",
 		},
 		{
 			// 1200 - 0.01 = 1199.99
@@ -87,24 +95,70 @@ func TestSub(t *testing.T) {
 			inputA: *resource.NewDecimalQuantity(*inf.NewDec(12, -2), resource.DecimalSI),
 			inputB: *resource.NewDecimalQuantity(*inf.NewDec(1, 2), resource.DecimalSI),
 			want:   *resource.NewDecimalQuantity(*inf.NewDec(119999, 2), resource.DecimalSI),
+			msg:    "Sub(DecimalSI, DecimalSI with decimal digits)",
 		},
 		{
 			// 10 - 10.00028 = -0.00028
 			inputA: *resource.NewScaledQuantity(1, 1),
 			inputB: *resource.NewScaledQuantity(1000028, -5),
 			want:   *resource.NewScaledQuantity(-28, -5),
+			msg:    "Sub(DecimalSI, DecimalSI with decimal digits), negative result",
 		},
 		{
-			// demonstrates for practical uses, cannot overflow
 			// [min(int64) x10^max(int32)] - [max(int64) x10^max(int32)]
 			inputA: *resource.NewScaledQuantity(-9223372036854775808, 2147483647),
 			inputB: *resource.NewScaledQuantity(9223372036854775807, 2147483647),
 			want:   *resource.NewDecimalQuantity(*inf.NewDecBig(bigInt, -2147483647), resource.DecimalSI),
+			msg:    "Sub(overflow testing)",
 		},
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.want, Sub(test.inputA, test.inputB))
+		assert.Equal(t, test.want, Sub(test.inputA, test.inputB), test.msg)
+	}
+}
+
+func TestMul(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		inputA resource.Quantity
+		inputB resource.Quantity
+		// roundingPrecision is the decimal place to compare want vs result due to loss of precision
+		roundingPrecision int32
+		want              resource.Quantity
+		msg               string
+	}{
+		{
+			inputA:            resource.MustParse("31.123456Gi"),
+			inputB:            resource.MustParse("8.123456789"),
+			want:              *resource.NewDecimalQuantity(*inf.NewDec(2714741989849547521, 7), resource.BinarySI),
+			roundingPrecision: -7, // 0.0000001 precision
+			msg:               "Mul(parsed BinarySI, parsed DecimalSI)",
+		},
+		{
+			// 12345600 * -0.003456 = -42666.3936
+			inputA:            *resource.NewDecimalQuantity(*inf.NewDec(123456, -2), resource.DecimalSI),
+			inputB:            *resource.NewDecimalQuantity(*inf.NewDec(-3456, 6), resource.DecimalSI),
+			want:              *resource.NewDecimalQuantity(*inf.NewDec(-426663936, 4), resource.DecimalSI),
+			roundingPrecision: -4, // 0.0001 precision
+			msg:               "Mul(DecimalSI, negative DecimalSI with decimal digits)",
+		},
+		{
+			inputA:            resource.MustParse("518Ti"),
+			inputB:            resource.MustParse("1234.56789"),
+			want:              *resource.NewDecimalQuantity(*inf.NewDec(7031444666729507272, 1), resource.BinarySI),
+			roundingPrecision: -1, // 0.1 precision
+			msg:               "Mul(overflow testing)",
+		},
+	}
+
+	for _, test := range tests {
+		result := Mul(test.inputA, test.inputB)
+		result.RoundUp(resource.Scale(test.roundingPrecision))
+		test.want.RoundUp(resource.Scale(test.roundingPrecision))
+
+		assert.Equal(t, test.want, result, test.msg)
 	}
 }
 
@@ -118,34 +172,35 @@ func TestMulFloat64(t *testing.T) {
 		// roundingPrecision is the decimal place to compare want vs result due to loss of precision
 		roundingPrecision int32
 		wantError         bool
+		msg               string
 	}{
 		{
-			// negative multiplier
 			inputA:            resource.MustParse("501Mi"),
 			inputB:            -0.123456,
 			want:              *resource.NewDecimalQuantity(*inf.NewDec(-64855952326656, 6), resource.BinarySI),
 			roundingPrecision: -6, // 0.000001 precision
+			msg:               "MulFloat64(parsed BinarySI, negative float)",
 		},
 		{
-			// positive multiplier
 			inputA:            resource.MustParse("31Gi"),
 			inputB:            2.525873,
 			want:              *resource.NewDecimalQuantity(*inf.NewDec(84076199948582912, 6), resource.BinarySI),
 			roundingPrecision: -6, // 0.000001 precision
+			msg:               "MulFloat64(parsed BinarySI, positive float)",
 		},
 		{
-			// repeating decimal multiplier
 			inputA:            resource.MustParse("31Gi"),
 			inputB:            10000 / 7.0,
 			want:              *resource.NewDecimalQuantity(*inf.NewDec(475514236344, -2), resource.BinarySI),
 			roundingPrecision: 2, // 10^2 precision
+			msg:               "MulFloat64(parsed BinarySI, repeating decimal)",
 		},
 		{
-			// overflow testing
 			inputA:            resource.MustParse("5Ei"),
 			inputB:            95.05,
 			want:              *resource.NewDecimalQuantity(*inf.NewDec(5479259450644040254, -2), resource.BinarySI),
 			roundingPrecision: 2, // 10^2 precision
+			msg:               "MulFloat64(overflow testing)",
 		},
 	}
 
@@ -157,8 +212,52 @@ func TestMulFloat64(t *testing.T) {
 			result.RoundUp(resource.Scale(test.roundingPrecision))
 			test.want.RoundUp(resource.Scale(test.roundingPrecision))
 
-			assert.Equal(t, test.want, result)
+			assert.Equal(t, test.want, result, test.msg)
 		}
+	}
+}
+
+func TestDiv(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		inputA resource.Quantity
+		inputB resource.Quantity
+		// roundingPrecision is the decimal place to compare want vs result due to loss of precision
+		roundingPrecision int32
+		want              resource.Quantity
+		msg               string
+	}{
+		{
+			inputA:            resource.MustParse("31.123456Gi"),
+			inputB:            resource.MustParse("8.123456789"),
+			want:              *resource.NewDecimalQuantity(*inf.NewDec(4113834453, 0), resource.BinarySI),
+			roundingPrecision: 0,
+			msg:               "Div(parsed BinarySI, parsed DecimalSI)",
+		},
+		{
+			// 12345600 / -0.003456 = -3572222222
+			inputA:            *resource.NewDecimalQuantity(*inf.NewDec(123456, -2), resource.DecimalSI),
+			inputB:            *resource.NewDecimalQuantity(*inf.NewDec(-3456, 6), resource.DecimalSI),
+			want:              *resource.NewDecimalQuantity(*inf.NewDec(-3572222223, 0), resource.DecimalSI),
+			roundingPrecision: 0,
+			msg:               "Div(DecimalSI, negative DecimalSI with decimal digits)",
+		},
+		{
+			inputA:            resource.MustParse("518Ti"),
+			inputB:            resource.MustParse("0.123456789"),
+			want:              *resource.NewDecimalQuantity(*inf.NewDec(4613330929803853, 0), resource.BinarySI),
+			roundingPrecision: 0,
+			msg:               "Div(overflow testing)",
+		},
+	}
+
+	for _, test := range tests {
+		result := Div(test.inputA, test.inputB)
+		result.RoundUp(resource.Scale(test.roundingPrecision))
+		test.want.RoundUp(resource.Scale(test.roundingPrecision))
+
+		assert.Equal(t, test.want, result, test.msg)
 	}
 }
 
@@ -166,32 +265,34 @@ func TestDivFloat64(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		inputA            resource.Quantity
-		inputB            float64
-		want              resource.Quantity
+		inputA resource.Quantity
+		inputB float64
+		want   resource.Quantity
+		// roundingPrecision is the decimal place to compare want vs result due to loss of precision
 		roundingPrecision int32
 		wantError         bool
+		msg               string
 	}{
 		{
-			// negative divisor
 			inputA:            resource.MustParse("256Mi"),
 			inputB:            -1 / 6.0,
 			want:              *resource.NewDecimalQuantity(*inf.NewDec(-1610612736, 0), resource.BinarySI),
-			roundingPrecision: 0,
+			roundingPrecision: 1, // precision to 10s
+			msg:               "DivFloat64(parsed BinarySI, negative repeating decimal)",
 		},
 		{
-			// positive divisor
 			inputA:            resource.MustParse("31Gi"),
 			inputB:            2.525873,
-			want:              *resource.NewDecimalQuantity(*inf.NewDec(13178016687, 0), resource.BinarySI),
-			roundingPrecision: 3, // KiB precision
+			want:              *resource.NewDecimalQuantity(*inf.NewDec(13178016688, 0), resource.BinarySI),
+			roundingPrecision: 0,
+			msg:               "DivFloat64(parsed BinarySI, positive float)",
 		},
 		{
-			// repeating decimal divisor
 			inputA:            resource.MustParse("5128Ti"),
-			inputB:            10.0 / 6.0,
-			want:              *resource.NewDecimalQuantity(*inf.NewDec(33829773763411968, 1), resource.BinarySI),
-			roundingPrecision: -1, // 0.1 precision
+			inputB:            10.0 / 3333.0,
+			want:              *resource.NewDecimalQuantity(*inf.NewDec(1879243932557534823, 0), resource.BinarySI),
+			roundingPrecision: 12, // precision to 10^12
+			msg:               "DivFloat64(overflow testing)",
 		},
 	}
 
@@ -203,7 +304,7 @@ func TestDivFloat64(t *testing.T) {
 			result.RoundUp(resource.Scale(test.roundingPrecision))
 			test.want.RoundUp(resource.Scale(test.roundingPrecision))
 
-			assert.Equal(t, test.want, result)
+			assert.Equal(t, test.want, result, test.msg)
 		}
 	}
 }

--- a/internal/quantity/quantity_test.go
+++ b/internal/quantity/quantity_test.go
@@ -16,62 +16,45 @@ func TestAdd(t *testing.T) {
 	bigInt := big.NewInt(0).SetUint64(18446744073709551614)
 
 	tests := []struct {
-		inputA       resource.Quantity
-		inputB       resource.Quantity
-		want         resource.Quantity
-		wantOverflow bool
+		inputA resource.Quantity
+		inputB resource.Quantity
+		want   resource.Quantity
 	}{
 		{
-			inputA:       *resource.NewQuantity(15000, resource.BinarySI),
-			inputB:       *resource.NewQuantity(17000, resource.BinarySI),
-			want:         *resource.NewQuantity(32000, resource.BinarySI),
-			wantOverflow: false,
+			inputA: resource.MustParse("31.123456Gi"),
+			inputB: resource.MustParse("27.654321Gi"),
+			want:   resource.MustParse("58.777777Gi"),
 		},
 		{
 			// binary + decimal = binary
-			inputA:       *resource.NewQuantity(11, resource.BinarySI),
-			inputB:       *resource.NewQuantity(34, resource.DecimalSI),
-			want:         *resource.NewQuantity(45, resource.BinarySI),
-			wantOverflow: false,
+			inputA: *resource.NewQuantity(11, resource.BinarySI),
+			inputB: *resource.NewQuantity(34, resource.DecimalSI),
+			want:   *resource.NewQuantity(45, resource.BinarySI),
 		},
 		{
 			// 1200 + 0.01 = 1200.01
 			// inf.Scale is negated, -2 means *100, 2 means *0.01
-			inputA:       *resource.NewDecimalQuantity(*inf.NewDec(12, -2), resource.DecimalSI),
-			inputB:       *resource.NewDecimalQuantity(*inf.NewDec(1, 2), resource.DecimalSI),
-			want:         *resource.NewDecimalQuantity(*inf.NewDec(120001, 2), resource.DecimalSI),
-			wantOverflow: false,
+			inputA: *resource.NewDecimalQuantity(*inf.NewDec(12, -2), resource.DecimalSI),
+			inputB: *resource.NewDecimalQuantity(*inf.NewDec(1, 2), resource.DecimalSI),
+			want:   *resource.NewDecimalQuantity(*inf.NewDec(120001, 2), resource.DecimalSI),
 		},
 		{
 			// -10 + 0.00028 = -9.99972
-			inputA:       *resource.NewScaledQuantity(-1, 1),
-			inputB:       *resource.NewScaledQuantity(28, -5),
-			want:         *resource.NewScaledQuantity(-999972, -5),
-			wantOverflow: false,
-		},
-		{
-			// overflow testing, max int64 is 9.223372036854775807x10^18
-			// use 123400*10^18 + 987600*10^18
-			inputA:       *resource.NewScaledQuantity(123400, resource.Exa),
-			inputB:       *resource.NewScaledQuantity(987600, resource.Exa),
-			want:         *resource.NewScaledQuantity(1111000, resource.Exa),
-			wantOverflow: false,
+			inputA: *resource.NewScaledQuantity(-1, 1),
+			inputB: *resource.NewScaledQuantity(28, -5),
+			want:   *resource.NewScaledQuantity(-999972, -5),
 		},
 		{
 			// demonstrates for practical uses, cannot overflow
 			// [max(int64) x10^max(int32)] + [max(int64) x10^max(int32)]
-			inputA:       *resource.NewScaledQuantity(9223372036854775807, 2147483647),
-			inputB:       *resource.NewScaledQuantity(9223372036854775807, 2147483647),
-			want:         *resource.NewDecimalQuantity(*inf.NewDecBig(bigInt, -2147483647), resource.DecimalSI),
-			wantOverflow: false,
+			inputA: *resource.NewScaledQuantity(9223372036854775807, 2147483647),
+			inputB: *resource.NewScaledQuantity(9223372036854775807, 2147483647),
+			want:   *resource.NewDecimalQuantity(*inf.NewDecBig(bigInt, -2147483647), resource.DecimalSI),
 		},
 	}
 
 	for _, test := range tests {
-		result, overflow := Add(test.inputA, test.inputB)
-
-		assert.Equal(t, test.want, result)
-		assert.Equal(t, test.wantOverflow, overflow)
+		assert.Equal(t, test.want, Add(test.inputA, test.inputB))
 	}
 }
 
@@ -83,62 +66,45 @@ func TestSub(t *testing.T) {
 	bigInt = bigInt.Neg(bigInt)
 
 	tests := []struct {
-		inputA       resource.Quantity
-		inputB       resource.Quantity
-		want         resource.Quantity
-		wantOverflow bool
+		inputA resource.Quantity
+		inputB resource.Quantity
+		want   resource.Quantity
 	}{
 		{
-			inputA:       resource.MustParse("31Gi"),
-			inputB:       resource.MustParse("27.2Gi"),
-			want:         resource.MustParse("3.8Gi"),
-			wantOverflow: false,
+			inputA: resource.MustParse("31Gi"),
+			inputB: resource.MustParse("27.2Gi"),
+			want:   resource.MustParse("3.8Gi"),
 		},
 		{
 			// binary - decimal = binary
-			inputA:       resource.MustParse("55Ki"),
-			inputB:       resource.MustParse("5000"),
-			want:         *resource.NewQuantity(51320, resource.BinarySI),
-			wantOverflow: false,
+			inputA: resource.MustParse("55Ki"),
+			inputB: resource.MustParse("5000"),
+			want:   *resource.NewQuantity(51320, resource.BinarySI),
 		},
 		{
 			// 1200 - 0.01 = 1199.99
 			// inf.Scale is negated, -2 means *100, 2 mean *0.01
-			inputA:       *resource.NewDecimalQuantity(*inf.NewDec(12, -2), resource.DecimalSI),
-			inputB:       *resource.NewDecimalQuantity(*inf.NewDec(1, 2), resource.DecimalSI),
-			want:         *resource.NewDecimalQuantity(*inf.NewDec(119999, 2), resource.DecimalSI),
-			wantOverflow: false,
+			inputA: *resource.NewDecimalQuantity(*inf.NewDec(12, -2), resource.DecimalSI),
+			inputB: *resource.NewDecimalQuantity(*inf.NewDec(1, 2), resource.DecimalSI),
+			want:   *resource.NewDecimalQuantity(*inf.NewDec(119999, 2), resource.DecimalSI),
 		},
 		{
 			// 10 - 10.00028 = -0.00028
-			inputA:       *resource.NewScaledQuantity(1, 1),
-			inputB:       *resource.NewScaledQuantity(1000028, -5),
-			want:         *resource.NewScaledQuantity(-28, -5),
-			wantOverflow: false,
-		},
-		{
-			// shouldn't overflow, min int64 is -9.223372036854775808x10^18
-			// use 123400*10^18 - 987600*10^18
-			inputA:       *resource.NewScaledQuantity(123400, resource.Exa),
-			inputB:       *resource.NewScaledQuantity(987600, resource.Exa),
-			want:         *resource.NewScaledQuantity(-864200, resource.Exa),
-			wantOverflow: false,
+			inputA: *resource.NewScaledQuantity(1, 1),
+			inputB: *resource.NewScaledQuantity(1000028, -5),
+			want:   *resource.NewScaledQuantity(-28, -5),
 		},
 		{
 			// demonstrates for practical uses, cannot overflow
 			// [min(int64) x10^max(int32)] - [max(int64) x10^max(int32)]
-			inputA:       *resource.NewScaledQuantity(-9223372036854775808, 2147483647),
-			inputB:       *resource.NewScaledQuantity(9223372036854775807, 2147483647),
-			want:         *resource.NewDecimalQuantity(*inf.NewDecBig(bigInt, -2147483647), resource.DecimalSI),
-			wantOverflow: false,
+			inputA: *resource.NewScaledQuantity(-9223372036854775808, 2147483647),
+			inputB: *resource.NewScaledQuantity(9223372036854775807, 2147483647),
+			want:   *resource.NewDecimalQuantity(*inf.NewDecBig(bigInt, -2147483647), resource.DecimalSI),
 		},
 	}
 
 	for _, test := range tests {
-		result, overflow := Sub(test.inputA, test.inputB)
-
-		assert.Equal(t, test.want, result)
-		assert.Equal(t, test.wantOverflow, overflow)
+		assert.Equal(t, test.want, Sub(test.inputA, test.inputB))
 	}
 }
 
@@ -146,24 +112,53 @@ func TestMulFloat64(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		inputA    resource.Quantity
-		inputB    float64
-		want      resource.Quantity
-		wantError error
+		inputA resource.Quantity
+		inputB float64
+		want   resource.Quantity
+		// roundingPrecision is the decimal place to compare want vs result due to loss of precision
+		roundingPrecision int32
+		wantError         bool
 	}{
 		{
-			inputA:    resource.MustParse("31Gi"),
-			inputB:    2.525873,
-			want:      *resource.NewDecimalQuantity(*inf.NewDec(84076199948582912, 6), resource.BinarySI),
-			wantError: nil,
+			// negative multiplier
+			inputA:            resource.MustParse("501Mi"),
+			inputB:            -0.123456,
+			want:              *resource.NewDecimalQuantity(*inf.NewDec(-64855952326656, 6), resource.BinarySI),
+			roundingPrecision: -6, // 0.000001 precision
+		},
+		{
+			// positive multiplier
+			inputA:            resource.MustParse("31Gi"),
+			inputB:            2.525873,
+			want:              *resource.NewDecimalQuantity(*inf.NewDec(84076199948582912, 6), resource.BinarySI),
+			roundingPrecision: -6, // 0.000001 precision
+		},
+		{
+			// repeating decimal multiplier
+			inputA:            resource.MustParse("31Gi"),
+			inputB:            10000 / 7.0,
+			want:              *resource.NewDecimalQuantity(*inf.NewDec(475514236344, -2), resource.BinarySI),
+			roundingPrecision: 2, // 10^2 precision
+		},
+		{
+			// overflow testing
+			inputA:            resource.MustParse("5Ei"),
+			inputB:            95.05,
+			want:              *resource.NewDecimalQuantity(*inf.NewDec(5479259450644040254, -2), resource.BinarySI),
+			roundingPrecision: 2, // 10^2 precision
 		},
 	}
 
 	for _, test := range tests {
 		result, err := MulFloat64(test.inputA, test.inputB)
+		if test.wantError {
+			assert.Error(t, err)
+		} else {
+			result.RoundUp(resource.Scale(test.roundingPrecision))
+			test.want.RoundUp(resource.Scale(test.roundingPrecision))
 
-		assert.Equal(t, test.want, result)
-		assert.Equal(t, test.wantError, err)
+			assert.Equal(t, test.want, result)
+		}
 	}
 }
 
@@ -173,26 +168,42 @@ func TestDivFloat64(t *testing.T) {
 	tests := []struct {
 		inputA            resource.Quantity
 		inputB            float64
-		roundingPrecision int32
 		want              resource.Quantity
-		wantError         error
+		roundingPrecision int32
+		wantError         bool
 	}{
 		{
+			// negative divisor
+			inputA:            resource.MustParse("256Mi"),
+			inputB:            -1 / 6.0,
+			want:              *resource.NewDecimalQuantity(*inf.NewDec(-1610612736, 0), resource.BinarySI),
+			roundingPrecision: 0,
+		},
+		{
+			// positive divisor
 			inputA:            resource.MustParse("31Gi"),
 			inputB:            2.525873,
-			roundingPrecision: 3, // KiB precision
 			want:              *resource.NewDecimalQuantity(*inf.NewDec(13178016687, 0), resource.BinarySI),
-			wantError:         nil,
+			roundingPrecision: 3, // KiB precision
+		},
+		{
+			// repeating decimal divisor
+			inputA:            resource.MustParse("5128Ti"),
+			inputB:            10.0 / 6.0,
+			want:              *resource.NewDecimalQuantity(*inf.NewDec(33829773763411968, 1), resource.BinarySI),
+			roundingPrecision: -1, // 0.1 precision
 		},
 	}
 
 	for _, test := range tests {
 		result, err := DivFloat64(test.inputA, test.inputB)
+		if test.wantError {
+			assert.Error(t, err)
+		} else {
+			result.RoundUp(resource.Scale(test.roundingPrecision))
+			test.want.RoundUp(resource.Scale(test.roundingPrecision))
 
-		result.RoundUp(resource.Scale(test.roundingPrecision))
-		test.want.RoundUp(resource.Scale(test.roundingPrecision))
-
-		assert.Equal(t, test.want, result)
-		assert.Equal(t, test.wantError, err)
+			assert.Equal(t, test.want, result)
+		}
 	}
 }


### PR DESCRIPTION
Adding Quantity management library with functions:
- Add(Quantity, Quantity)
- Sub(Quantity, Quantity)
- Mul(Quantity, Quantity)
- MulFloat64(Quantity, Float64)
- Div(Quantity, Quantity)
- DivFloat64(Quantity, Float64)

These functions make use of Go's [inf.Dec](https://pkg.go.dev/gopkg.in/inf.v0) lib to avoid using floating point calculations (avoid overflow), and uses k8s.io [ParseQuantity](https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go#L275) to parse from Float64 to Quantity.

There is a loss of precision with `Mul`/`MulFloat64`, and `Div`/`DivFloat64`. See the test cases with `roundingPrecision` greater than 0 which means round up to 10^x (x places left of the decimal).

The loss of precision is acceptable I think because the worst test on `DivFloat64` where loss of precision is 10^12, it is still a small fraction of the result 1.879..x10^18. Meaning, if this was a value in Gigabytes, the loss of precision would be on the order of Kilobytes.

`Div` and `DivFloat64` uses [QuoRound](https://pkg.go.dev/gopkg.in/inf.v0#Dec.QuoRound) and rounds up to the nearest whole number (Scale=0). It cannot have a precision better than a whole number, meaning no floating point digits. This is acceptable I think because the resource limits would never need fractions.

To double check the large values, I used [wolfram-alpha](https://www.wolframalpha.com/input?i=%28518+*+%281024%5E4%29%29%2F0.123456789)