### PR TITLE
Mutation webhook router

### DIFF
--- a/examples/k8s/deployment.yaml
+++ b/examples/k8s/deployment.yaml
@@ -38,7 +38,13 @@ spec:
       containers:
         - name: hedgetrimmer
           image: registry.example.com/hedgetrimmer:latest
+          args:
+            - "--log-level=debug"
           imagePullPolicy: Always
+          volumeMounts:
+            - name: webhook-certs
+              mountPath: /etc/webhook/certs
+              readOnly: true
           livenessProbe:
             httpGet:
               path: /healthz
@@ -59,6 +65,10 @@ spec:
             - containerPort: 8080
               name: probes
       serviceAccountName: hedgetrimmer
+      volumes:
+        - name: webhook-certs
+          secret:
+            secretName: hedgetrimmer
 
 ---   
 apiVersion: v1

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/spf13/viper v1.13.0
 	github.com/stretchr/testify v1.8.0
 	go.uber.org/zap v1.23.0
+	k8s.io/api v0.25.0
 	k8s.io/apimachinery v0.25.0
 	k8s.io/cli-runtime v0.25.0
 	k8s.io/client-go v0.25.0
@@ -86,7 +87,7 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.25.0 // indirect
+	k8s.io/apiextensions-apiserver v0.25.0 // indirect
 	k8s.io/component-base v0.25.0 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -718,6 +718,7 @@ honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 k8s.io/api v0.25.0 h1:H+Q4ma2U/ww0iGB78ijZx6DRByPz6/733jIuFpX70e0=
 k8s.io/api v0.25.0/go.mod h1:ttceV1GyV1i1rnmvzT3BST08N6nGt+dudGrquzVQWPk=
 k8s.io/apiextensions-apiserver v0.25.0 h1:CJ9zlyXAbq0FIW8CD7HHyozCMBpDSiH7EdrSTCZcZFY=
+k8s.io/apiextensions-apiserver v0.25.0/go.mod h1:3pAjZiN4zw7R8aZC5gR0y3/vCkGlAjCazcg1me8iB/E=
 k8s.io/apimachinery v0.25.0 h1:MlP0r6+3XbkUG2itd6vp3oxbtdQLQI94fD5gCS+gnoU=
 k8s.io/apimachinery v0.25.0/go.mod h1:qMx9eAk0sZQGsXGu86fab8tZdffHbwUfsvzqKn4mfB0=
 k8s.io/cli-runtime v0.25.0 h1:XBnTc2Fi+w818jcJGzhiJKQuXl8479sZ4FhtV5hVJ1Q=

--- a/internal/admission/admission.go
+++ b/internal/admission/admission.go
@@ -1,0 +1,73 @@
+package admission
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type AdmissionHandler interface {
+	admission.Handler
+	Kind() string
+	InjectDecoder(*admission.Decoder) error
+}
+
+type OptionsFunc func(*Router) error
+
+func WithAdmissionHandlers(handlers ...AdmissionHandler) OptionsFunc {
+	return func(r *Router) error {
+		for _, h := range handlers {
+			if _, ok := r.handlers[h.Kind()]; ok {
+				return fmt.Errorf("duplicate handler %s registered", h.Kind())
+			}
+			r.handlers[h.Kind()] = h
+		}
+		return nil
+	}
+}
+
+type Router struct {
+	handlers map[string]AdmissionHandler
+}
+
+func NewRouter(opts ...OptionsFunc) (*Router, error) {
+	r := &Router{
+		handlers: map[string]AdmissionHandler{},
+	}
+
+	for _, opt := range opts {
+		if err := opt(r); err != nil {
+			return nil, err
+		}
+	}
+
+	return r, nil
+}
+
+func (r *Router) SetupWithManager(m manager.Manager) {
+	m.GetWebhookServer().Register("/mutate", &webhook.Admission{Handler: r})
+}
+
+func (r *Router) InjectDecoder(d *admission.Decoder) error {
+	if d == nil {
+		return fmt.Errorf("decoder cannot be nil")
+	}
+	for _, h := range r.handlers {
+		if err := h.InjectDecoder(d); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Router) Handle(ctx context.Context, req admission.Request) admission.Response {
+	if h, ok := r.handlers[req.RequestKind.Kind]; ok {
+		return h.Handle(ctx, req)
+	}
+
+	return admission.Errored(http.StatusBadRequest, fmt.Errorf("resource %s not implemented", req.RequestKind.Kind))
+}

--- a/internal/admission/admission_test.go
+++ b/internal/admission/admission_test.go
@@ -1,0 +1,216 @@
+package admission
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/kanopy-platform/hedgetrimmer/pkg/admission/handlers"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/admission/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var cfg *rest.Config
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	testenv := &envtest.Environment{}
+	if !testing.Short() {
+		testenv := &envtest.Environment{}
+		var err error
+		cfg, err = testenv.Start()
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	res := m.Run()
+
+	if !testing.Short() {
+		if err := testenv.Stop(); err != nil {
+			panic(err)
+		}
+	}
+
+	os.Exit(res)
+}
+
+func TestNewAdmissionRouter(t *testing.T) {
+	t.Parallel()
+	r, err := NewRouter()
+	assert.NoError(t, err)
+	assert.NotNil(t, r)
+
+}
+
+func TestIntegrationSetupWithManager(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip()
+	}
+	r, err := NewRouter()
+	assert.NoError(t, err)
+	m, err := manager.New(cfg, manager.Options{
+		Scheme: &runtime.Scheme{},
+		Port:   8084,
+		Host:   "127.0.0.1",
+	})
+
+	assert.NoError(t, err)
+	r.SetupWithManager(m)
+}
+
+func TestWithAdmissonHandlers_AddHandler(t *testing.T) {
+	t.Parallel()
+	r, err := NewRouter(WithAdmissionHandlers(&MockDeploymentHandler{}))
+	assert.NoError(t, err)
+	assert.Len(t, r.handlers, 1)
+}
+
+func TestWithAdmissionHandlers_AddDuplciateHandlerFails(t *testing.T) {
+	t.Parallel()
+	r, err := NewRouter(WithAdmissionHandlers(&MockDeploymentHandler{}, &MockDeploymentHandler{}))
+	assert.Error(t, err)
+	assert.Nil(t, r)
+}
+
+func TestAllowObjects(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	decoder, err := admission.NewDecoder(scheme)
+	assert.NoError(t, err)
+	r, err := NewRouter(WithAdmissionHandlers(&MockDeploymentHandler{}, &MockReplicaSetHandler{}))
+	assert.NoError(t, err)
+	assert.NoError(t, r.InjectDecoder(decoder))
+
+	tests := []struct {
+		object      runtime.Object
+		wantAllowed bool
+	}{
+		{
+			object: &appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: "apps/v1",
+				},
+			},
+			wantAllowed: true,
+		},
+		{
+			object: &appsv1.ReplicaSet{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ReplicaSet",
+					APIVersion: "apps/v1",
+				},
+			},
+			wantAllowed: true,
+		},
+		{
+			object: &appsv1.ReplicaSet{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "Unknown",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		b, err := json.Marshal(test.object)
+		assert.NoError(t, err)
+		response := r.Handle(context.TODO(), admission.Request{AdmissionRequest: v1.AdmissionRequest{
+			RequestKind: &metav1.GroupVersionKind{
+				Kind: test.object.GetObjectKind().GroupVersionKind().Kind,
+			},
+			Object: runtime.RawExtension{
+				Raw: b,
+			},
+		}})
+
+		assert.Equal(t, test.wantAllowed, response.Allowed, fmt.Sprintf("allow test on %s", test.object.GetObjectKind().GroupVersionKind().Kind))
+
+		patchLengthWant := 0
+		if test.wantAllowed {
+			patchLengthWant = 1
+		}
+
+		assert.Len(t, response.Patches, patchLengthWant, fmt.Sprintf("patches assert on %s", test.object.GetObjectKind().GroupVersionKind().Kind))
+
+	}
+}
+
+type MockDeploymentHandler struct {
+	handlers.DefaultHandler
+}
+
+func (d *MockDeploymentHandler) Kind() string {
+	return "Deployment"
+}
+
+func (d *MockDeploymentHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	deployment := &appsv1.Deployment{}
+	if err := d.Decoder.Decode(req, deployment); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	pjson, err := json.Marshal(d.mutate(deployment))
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	return admission.PatchResponseFromRaw(req.Object.Raw, pjson)
+}
+
+func (d *MockDeploymentHandler) mutate(dp *appsv1.Deployment) *appsv1.Deployment {
+	patched := dp.DeepCopy()
+	if patched.Annotations == nil {
+		patched.Annotations = map[string]string{}
+	}
+	patched.Annotations["mutated"] = "deployment"
+	return patched
+}
+
+type MockReplicaSetHandler struct {
+	handlers.DefaultHandler
+}
+
+func (r *MockReplicaSetHandler) Kind() string {
+	return "ReplicaSet"
+}
+
+func (r *MockReplicaSetHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+
+	rs := &appsv1.ReplicaSet{}
+
+	if err := r.Decoder.Decode(req, rs); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	pjson, err := json.Marshal(r.mutate(rs))
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	return admission.PatchResponseFromRaw(req.Object.Raw, pjson)
+}
+
+func (r *MockReplicaSetHandler) mutate(rs *appsv1.ReplicaSet) *appsv1.ReplicaSet {
+	patched := rs.DeepCopy()
+
+	if patched.Annotations == nil {
+		patched.Annotations = map[string]string{}
+	}
+	patched.Annotations["mutated"] = "replicaset"
+
+	return patched
+}

--- a/internal/admission/admission_test.go
+++ b/internal/admission/admission_test.go
@@ -163,12 +163,7 @@ func (d *MockDeploymentHandler) Handle(ctx context.Context, req admission.Reques
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	pjson, err := json.Marshal(d.mutate(deployment))
-	if err != nil {
-		return admission.Errored(http.StatusBadRequest, err)
-	}
-
-	return admission.PatchResponseFromRaw(req.Object.Raw, pjson)
+	return d.PatchResponse(req.Object.Raw, d.mutate(deployment))
 }
 
 func (d *MockDeploymentHandler) mutate(dp *appsv1.Deployment) *appsv1.Deployment {
@@ -196,12 +191,7 @@ func (r *MockReplicaSetHandler) Handle(ctx context.Context, req admission.Reques
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	pjson, err := json.Marshal(r.mutate(rs))
-	if err != nil {
-		return admission.Errored(http.StatusBadRequest, err)
-	}
-
-	return admission.PatchResponseFromRaw(req.Object.Raw, pjson)
+	return r.PatchResponse(req.Object.Raw, r.mutate(rs))
 }
 
 func (r *MockReplicaSetHandler) mutate(rs *appsv1.ReplicaSet) *appsv1.ReplicaSet {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
+	"github.com/kanopy-platform/hedgetrimmer/internal/admission"
 	logzap "github.com/kanopy-platform/hedgetrimmer/internal/log/zap"
 
 	"github.com/spf13/cobra"
@@ -104,7 +105,12 @@ func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// TODO add mutation handler
+	admissionRouter, err := admission.NewRouter()
+	if err != nil {
+		return err
+	}
+
+	admissionRouter.SetupWithManager(mgr)
 
 	return mgr.Start(ctx)
 }

--- a/pkg/admission/handlers/default.go
+++ b/pkg/admission/handlers/default.go
@@ -1,0 +1,29 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type DefaultHandler struct {
+	Decoder *admission.Decoder
+}
+
+func (dh *DefaultHandler) Kind() string {
+	return "default"
+}
+
+func (dh *DefaultHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	return admission.Errored(http.StatusBadRequest, fmt.Errorf("resource %s not implemented", dh.Kind()))
+}
+
+func (dh *DefaultHandler) InjectDecoder(d *admission.Decoder) error {
+	if d == nil {
+		return fmt.Errorf("decoder cannot be nil")
+	}
+	dh.Decoder = d
+	return nil
+}

--- a/pkg/admission/handlers/default.go
+++ b/pkg/admission/handlers/default.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -26,4 +27,13 @@ func (dh *DefaultHandler) InjectDecoder(d *admission.Decoder) error {
 	}
 	dh.Decoder = d
 	return nil
+}
+
+func (dh *DefaultHandler) PatchResponse(raw []byte, v interface{}) admission.Response {
+	pjson, err := json.Marshal(v)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	return admission.PatchResponseFromRaw(raw, pjson)
 }

--- a/pkg/admission/handlers/default_test.go
+++ b/pkg/admission/handlers/default_test.go
@@ -27,3 +27,20 @@ func TestDefaultHandler_InjectDecoder(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, h.InjectDecoder(decoder))
 }
+
+func TestDefaultHandler_PatchResponse_ErrorsOnNil(t *testing.T) {
+	h := &DefaultHandler{}
+	resp := h.PatchResponse([]byte{}, "not json")
+	assert.Equal(t, false, resp.Allowed)
+}
+
+func TestDefaultHandler_PatchResponse_OK(t *testing.T) {
+	h := &DefaultHandler{}
+	d := struct {
+		Hello string
+	}{
+		Hello: "world",
+	}
+	resp := h.PatchResponse([]byte("{}"), &d)
+	assert.Equal(t, true, resp.Allowed)
+}

--- a/pkg/admission/handlers/default_test.go
+++ b/pkg/admission/handlers/default_test.go
@@ -1,0 +1,29 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func TestDefaultHandler_HandleNotImplemented(t *testing.T) {
+	h := &DefaultHandler{}
+	r := h.Handle(context.TODO(), admission.Request{})
+	assert.False(t, r.Allowed)
+}
+
+func TestDefaultHandler_InjectDecoder_FailsOnNil(t *testing.T) {
+	h := &DefaultHandler{}
+	assert.Error(t, h.InjectDecoder(nil))
+}
+
+func TestDefaultHandler_InjectDecoder(t *testing.T) {
+	h := &DefaultHandler{}
+	scheme := runtime.NewScheme()
+	decoder, err := admission.NewDecoder(scheme)
+	assert.NoError(t, err)
+	assert.NoError(t, h.InjectDecoder(decoder))
+}


### PR DESCRIPTION
This router accepts and routes an `AdmissionHandler` per `Kind`.  Only one AdmissionHandler is executed per `Kind`.
The `DefaultHandler` is designed to simply the process of supporting new `Kind` objects for mutation.   The root router is configured with the controller manager.


## Developing `Kind` Handlers
Handlers per kind will go in the `pkg/admission/handlers` package.  A sample implementation of the `AdmissionHandler` interface is seen in `admission_test.go` and below.

```golang
func (d *MockDeploymentHandler) Kind() string {
	return "Deployment"
}

func (d *MockDeploymentHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
	deployment := &appsv1.Deployment{}
	if err := d.Decoder.Decode(req, deployment); err != nil {
		return admission.Errored(http.StatusBadRequest, err)
	}
	return d.PatchResponse(req.Object.Raw, d.mutate(deployment))
}

func (d *MockDeploymentHandler) mutate(dp *appsv1.Deployment) *appsv1.Deployment {
	return db.DeepCopy()
}
```