### PR TITLE
New incomplete limitrange lib

### DIFF
--- a/internal/limitrange/limitrange.go
+++ b/internal/limitrange/limitrange.go
@@ -1,0 +1,19 @@
+package limitrange
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+func IsLimitRangeTypeContainer(lri corev1.LimitRangeItem) bool {
+	return lri.Type == corev1.LimitTypeContainer
+}
+
+func NewConfig(lri corev1.LimitRangeItem, resource corev1.ResourceName) Config {
+	l := Config{}
+
+	l.DefaultRequest, l.HasDefaultRequest = lri.DefaultRequest[resource]
+	l.DefaultLimit, l.HasDefaultLimit = lri.Default[resource]
+	l.MaxLimitRequestRatio, l.HasMaxLimitRequestRatio = lri.MaxLimitRequestRatio[resource]
+
+	return l
+}

--- a/internal/limitrange/limitrange_test.go
+++ b/internal/limitrange/limitrange_test.go
@@ -1,0 +1,100 @@
+package limitrange
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestIsLimitRangeTypeContainer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		limitRange corev1.LimitRangeItem
+		want       bool
+		msg        string
+	}{
+		{
+			limitRange: corev1.LimitRangeItem{Type: corev1.LimitTypeContainer},
+			want:       true,
+			msg:        "Container type",
+		},
+		{
+			limitRange: corev1.LimitRangeItem{Type: corev1.LimitTypePod},
+			want:       false,
+			msg:        "Pod type",
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.want, IsLimitRangeTypeContainer(test.limitRange), test.msg)
+	}
+}
+
+func TestNewConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		limitRange corev1.LimitRangeItem
+		resource   corev1.ResourceName
+		want       Config
+		msg        string
+	}{
+		{
+			// extract out memory resource
+			limitRange: corev1.LimitRangeItem{
+				DefaultRequest: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+				},
+				Default: corev1.ResourceList{
+					corev1.ResourceMemory:  resource.MustParse("2Gi"),
+					corev1.ResourceStorage: resource.MustParse("5Gi"),
+				},
+				MaxLimitRequestRatio: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("1.5"),
+				},
+			},
+			resource: corev1.ResourceMemory,
+			want: Config{
+				HasDefaultRequest:       true,
+				HasDefaultLimit:         true,
+				HasMaxLimitRequestRatio: true,
+				DefaultRequest:          resource.MustParse("1Gi"),
+				DefaultLimit:            resource.MustParse("2Gi"),
+				MaxLimitRequestRatio:    resource.MustParse("1.5"),
+			},
+			msg: "extract out memory resource",
+		},
+		{
+			// extract out CPU resource
+			limitRange: corev1.LimitRangeItem{
+				DefaultRequest: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Default: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("5Gi"),
+				},
+				MaxLimitRequestRatio: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1.5"),
+				},
+			},
+			resource: corev1.ResourceCPU,
+			want: Config{
+				HasDefaultRequest:       true,
+				HasDefaultLimit:         false,
+				HasMaxLimitRequestRatio: true,
+				DefaultRequest:          resource.MustParse("500m"),
+				MaxLimitRequestRatio:    resource.MustParse("1.5"),
+			},
+			msg: "extract out CPU resource",
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.want, NewConfig(test.limitRange, test.resource), test.msg)
+	}
+}

--- a/internal/limitrange/types.go
+++ b/internal/limitrange/types.go
@@ -1,0 +1,12 @@
+package limitrange
+
+import "k8s.io/apimachinery/pkg/api/resource"
+
+type Config struct {
+	HasDefaultRequest       bool
+	HasDefaultLimit         bool
+	HasMaxLimitRequestRatio bool
+	DefaultLimit            resource.Quantity
+	DefaultRequest          resource.Quantity
+	MaxLimitRequestRatio    resource.Quantity
+}


### PR DESCRIPTION
Starting a new `limitrange` lib.
Currently it only has basic functionality for determining if type is Container, and extracting out a specified resource from a `LimitRangeItem` into a `Config`.

Additional functionality will be added in subsequent PRs.