### PR TITLE
Limit Range Config Abstraction

### DIFF
--- a/internal/admission/limitrange.go
+++ b/internal/admission/limitrange.go
@@ -7,5 +7,5 @@ import (
 
 type LimitRanger interface {
 	corev1Listers.LimitRangeLister
-	NewConfig(namespace string) limitrange.Config
+	NewConfig(namespace string) (*limitrange.Config, error)
 }

--- a/internal/admission/limitrange.go
+++ b/internal/admission/limitrange.go
@@ -7,5 +7,5 @@ import (
 
 type LimitRanger interface {
 	corev1Listers.LimitRangeLister
-	NewConfig(namespace string) (*limitrange.Config, error)
+	LimitRangeConfig(namespace string) (*limitrange.Config, error)
 }

--- a/internal/admission/limitrange.go
+++ b/internal/admission/limitrange.go
@@ -1,0 +1,11 @@
+package admission
+
+import (
+	"github.com/kanopy-platform/hedgetrimmer/internal/limitrange"
+	corev1Listers "k8s.io/client-go/listers/core/v1"
+)
+
+type LimitRanger interface {
+	corev1Listers.LimitRangeLister
+	NewConfig(namespace string) limitrange.Config
+}

--- a/internal/limitrange/limitrange.go
+++ b/internal/limitrange/limitrange.go
@@ -27,8 +27,8 @@ type LimitRange struct {
 	lister corev1Listers.LimitRangeLister
 }
 
-//NewConfig takes a namespace string and returns a Config for memory or a nil if no limit range of type Container is found in the namespace. It returns a non-nil error if there is an error sourcing data from the cluster api or the namespace name is empty
-func (lr *LimitRange) NewConfig(namespace string) (*Config, error) {
+//LimitRangeConfig takes a namespace string and returns a Config for memory or a nil if no limit range of type Container is found in the namespace. It returns a non-nil error if there is an error sourcing data from the cluster api or the namespace name is empty
+func (lr *LimitRange) LimitRangeConfig(namespace string) (*Config, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("Invalid namespace: %q", namespace)
 	}

--- a/internal/limitrange/limitrange.go
+++ b/internal/limitrange/limitrange.go
@@ -1,7 +1,11 @@
 package limitrange
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	corev1Listers "k8s.io/client-go/listers/core/v1"
 )
 
 func IsLimitRangeTypeContainer(lri corev1.LimitRangeItem) bool {
@@ -16,4 +20,30 @@ func NewConfig(lri corev1.LimitRangeItem, resource corev1.ResourceName) Config {
 	l.MaxLimitRequestRatio, l.HasMaxLimitRequestRatio = lri.MaxLimitRequestRatio[resource]
 
 	return l
+}
+
+//LimitRange provides an implementation of the LimitRanger interface defined in admission. This implementation is designed to provider a generic config sourcing tool for all mutation handlers.
+type LimitRange struct {
+	lister corev1Listers.LimitRangeLister
+}
+
+//NewConfig takes a namespace string and returns a Config for memory or a nil if no limit range of type Container is found in the namespace. It returns a non-nil error if there is an error sourcing data from the cluster api or the namespace name is empty
+func (lr *LimitRange) NewConfig(namespace string) (*Config, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("Invalid namespace: %q", namespace)
+	}
+	ranges, err := lr.lister.LimitRanges(namespace).List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	for _, lr := range ranges {
+		for _, item := range lr.Spec.Limits {
+			if item.Type == corev1.LimitTypeContainer {
+				config := NewConfig(item, corev1.ResourceMemory)
+				return &config, nil
+			}
+		}
+	}
+	return nil, nil
 }

--- a/internal/limitrange/limitrange_test.go
+++ b/internal/limitrange/limitrange_test.go
@@ -88,7 +88,7 @@ func TestLimitRanger(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		c, e := test.lr.NewConfig(test.ns)
+		c, e := test.lr.LimitRangeConfig(test.ns)
 		assert.Equal(t, test.wantError, e != nil)
 		assert.Equal(t, test.want, c)
 	}
@@ -119,7 +119,7 @@ func TestIsLimitRangeTypeContainer(t *testing.T) {
 	}
 }
 
-func TestNewConfig(t *testing.T) {
+func TestLimitRangeConfig(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {


### PR DESCRIPTION
All handlers will have to source a config from the limit ranges in the namespace for a resource so this wraps that behavior in an interface and provides an implementation.

More concretely this type will receive a LimitRangeLister from an informer created during controller creation time and can be passed to the handlers as a shared resource. 

I didn't provide a constructor since there is only a single member that is an interface type that can be assigned. 