### PR TITLE
Refactor mutator inferface accepts pointer

### DIFF
--- a/internal/admission/mutator.go
+++ b/internal/admission/mutator.go
@@ -6,5 +6,5 @@ import (
 )
 
 type PodTemplateSpecMutator interface {
-	Mutate(inputPts corev1.PodTemplateSpec, limitRangeMemory limitrange.Config) (corev1.PodTemplateSpec, error)
+	Mutate(inputPts corev1.PodTemplateSpec, limitRangeMemory *limitrange.Config) (corev1.PodTemplateSpec, error)
 }

--- a/internal/limitrange/limitrange.go
+++ b/internal/limitrange/limitrange.go
@@ -27,6 +27,11 @@ type LimitRange struct {
 	lister corev1Listers.LimitRangeLister
 }
 
+//NewLimitRanger take a limitrangelister and returns a pointer to a configured LimitRange. This satisfies the LimitRanger interface
+func NewLimitRanger(lister corev1Listers.LimitRangeLister) *LimitRange {
+	return &LimitRange{lister: lister}
+}
+
 //LimitRangeConfig takes a namespace string and returns a Config for memory or a nil if no limit range of type Container is found in the namespace. It returns a non-nil error if there is an error sourcing data from the cluster api or the namespace name is empty
 func (lr *LimitRange) LimitRangeConfig(namespace string) (*Config, error) {
 	if namespace == "" {

--- a/internal/mutators/podtemplatespec.go
+++ b/internal/mutators/podtemplatespec.go
@@ -25,8 +25,12 @@ func NewPodTemplateSpec(opts ...OptionsFunc) *PodTemplateSpec {
 	return pts
 }
 
-func (p *PodTemplateSpec) Mutate(inputPts corev1.PodTemplateSpec, limitRangeMemory limitrange.Config) (corev1.PodTemplateSpec, error) {
+func (p *PodTemplateSpec) Mutate(inputPts corev1.PodTemplateSpec, limitRangeMemory *limitrange.Config) (corev1.PodTemplateSpec, error) {
+
 	pts := *inputPts.DeepCopy()
+	if limitRangeMemory == nil {
+		return pts, fmt.Errorf("invalid limit range config")
+	}
 
 	if err := p.setAndValidateResourceRequirements(pts.Spec.InitContainers, limitRangeMemory); err != nil {
 		return pts, err
@@ -39,7 +43,7 @@ func (p *PodTemplateSpec) Mutate(inputPts corev1.PodTemplateSpec, limitRangeMemo
 	return pts, nil
 }
 
-func (p *PodTemplateSpec) setAndValidateResourceRequirements(containers []corev1.Container, limitRangeMemory limitrange.Config) error {
+func (p *PodTemplateSpec) setAndValidateResourceRequirements(containers []corev1.Container, limitRangeMemory *limitrange.Config) error {
 	for idx := range containers {
 		container := &containers[idx]
 
@@ -54,7 +58,7 @@ func (p *PodTemplateSpec) setAndValidateResourceRequirements(containers []corev1
 	return nil
 }
 
-func (p *PodTemplateSpec) validateMemoryRequirements(container corev1.Container, limitRangeMemory limitrange.Config) error {
+func (p *PodTemplateSpec) validateMemoryRequirements(container corev1.Container, limitRangeMemory *limitrange.Config) error {
 	memoryRequest := container.Resources.Requests.Memory()
 	memoryLimit := container.Resources.Limits.Memory()
 
@@ -77,7 +81,7 @@ func (p *PodTemplateSpec) validateMemoryRequirements(container corev1.Container,
 	return nil
 }
 
-func (p *PodTemplateSpec) setMemoryRequest(container *corev1.Container, limitRangeMemory limitrange.Config) {
+func (p *PodTemplateSpec) setMemoryRequest(container *corev1.Container, limitRangeMemory *limitrange.Config) {
 	memoryRequest := container.Resources.Requests.Memory()
 	memoryLimit := container.Resources.Limits.Memory()
 
@@ -98,7 +102,7 @@ func (p *PodTemplateSpec) setMemoryRequest(container *corev1.Container, limitRan
 	}
 }
 
-func (p *PodTemplateSpec) setMemoryLimit(container *corev1.Container, limitRangeMemory limitrange.Config) {
+func (p *PodTemplateSpec) setMemoryLimit(container *corev1.Container, limitRangeMemory *limitrange.Config) {
 	memoryRequest := container.Resources.Requests.Memory()
 	memoryLimit := container.Resources.Limits.Memory()
 

--- a/internal/mutators/podtemplatespec_test.go
+++ b/internal/mutators/podtemplatespec_test.go
@@ -21,7 +21,7 @@ func TestMain(m *testing.M) {
 func TestMutate(t *testing.T) {
 	t.Parallel()
 
-	limitRangeMemory := limitrange.Config{
+	limitRangeMemory := &limitrange.Config{
 		HasDefaultRequest:       true,
 		HasDefaultLimit:         true,
 		HasMaxLimitRequestRatio: false,
@@ -32,7 +32,7 @@ func TestMutate(t *testing.T) {
 	tests := []struct {
 		msg        string
 		containers []corev1.Container
-		config     limitrange.Config
+		config     *limitrange.Config
 		want       []corev1.Container
 		wantError  bool
 	}{
@@ -118,7 +118,7 @@ func TestMutate(t *testing.T) {
 func TestValidateMemoryRatio(t *testing.T) {
 	t.Parallel()
 
-	memoryConfig := limitrange.Config{
+	memoryConfig := &limitrange.Config{
 		HasMaxLimitRequestRatio: true,
 		MaxLimitRequestRatio:    resource.MustParse("1.25"),
 	}
@@ -126,7 +126,7 @@ func TestValidateMemoryRatio(t *testing.T) {
 	tests := []struct {
 		requests  corev1.ResourceList
 		limits    corev1.ResourceList
-		mc        limitrange.Config
+		mc        *limitrange.Config
 		wantError bool
 		msg       string
 	}{
@@ -148,7 +148,7 @@ func TestValidateMemoryRatio(t *testing.T) {
 			msg:       "LimitRange does not specify max ratio, no ratio check",
 			requests:  corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")},
 			limits:    corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1.26Gi")},
-			mc:        limitrange.Config{HasMaxLimitRequestRatio: false},
+			mc:        &limitrange.Config{HasMaxLimitRequestRatio: false},
 			wantError: false,
 		},
 		{
@@ -194,7 +194,7 @@ func TestValidateMemoryRatio(t *testing.T) {
 func TestSetMemoryRequest(t *testing.T) {
 	t.Parallel()
 
-	memoryConfig := limitrange.Config{
+	memoryConfig := &limitrange.Config{
 		HasDefaultRequest: true,
 		HasDefaultLimit:   true,
 		DefaultRequest:    resource.MustParse("5Gi"),
@@ -204,7 +204,7 @@ func TestSetMemoryRequest(t *testing.T) {
 	tests := []struct {
 		requests     corev1.ResourceList
 		limits       corev1.ResourceList
-		mc           limitrange.Config
+		mc           *limitrange.Config
 		wantRequests corev1.ResourceList
 		msg          string
 	}{
@@ -231,7 +231,7 @@ func TestSetMemoryRequest(t *testing.T) {
 			msg:      "Memory request and limit does not exist, but default limit is set, set request = defaultLimit",
 			requests: nil,
 			limits:   nil,
-			mc: limitrange.Config{
+			mc: &limitrange.Config{
 				HasDefaultLimit: true,
 				DefaultLimit:    resource.MustParse("100Mi"),
 			},
@@ -240,7 +240,7 @@ func TestSetMemoryRequest(t *testing.T) {
 		{
 			msg:      "Memory request and limit does not exist and LimitRange does not have default request or limit, do not set",
 			requests: corev1.ResourceList{},
-			mc: limitrange.Config{
+			mc: &limitrange.Config{
 				HasDefaultRequest: false,
 				HasDefaultLimit:   false,
 			},
@@ -271,13 +271,13 @@ func TestSetMemoryRequest(t *testing.T) {
 func TestSetMemoryLimit(t *testing.T) {
 	t.Parallel()
 
-	memoryConfigWithoutMaxRatio := limitrange.Config{
+	memoryConfigWithoutMaxRatio := &limitrange.Config{
 		HasDefaultLimit:         true,
 		HasMaxLimitRequestRatio: false,
 		DefaultLimit:            resource.MustParse("50Mi"),
 	}
 
-	memoryConfigWithMaxRatio := limitrange.Config{
+	memoryConfigWithMaxRatio := &limitrange.Config{
 		HasDefaultLimit:         true,
 		HasMaxLimitRequestRatio: true,
 		DefaultLimit:            resource.MustParse("50Mi"),
@@ -287,7 +287,7 @@ func TestSetMemoryLimit(t *testing.T) {
 	tests := []struct {
 		requests   corev1.ResourceList
 		limits     corev1.ResourceList
-		mc         limitrange.Config
+		mc         *limitrange.Config
 		wantLimits corev1.ResourceList
 		msg        string
 	}{
@@ -302,7 +302,7 @@ func TestSetMemoryLimit(t *testing.T) {
 			msg:        "Memory request and limit not set, config does not have defaults, do not set",
 			requests:   corev1.ResourceList{},
 			limits:     corev1.ResourceList{},
-			mc:         limitrange.Config{},
+			mc:         &limitrange.Config{},
 			wantLimits: corev1.ResourceList{},
 		},
 		{
@@ -337,7 +337,7 @@ func TestSetMemoryLimit(t *testing.T) {
 			msg:      "MaxLimitRequestMemoryRatio set, defaultMemoryLimit and defaultLimitRequestMemoryRatio both smaller, use MaxLimitRequestMemoryRatio",
 			requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("50Gi")},
 			limits:   corev1.ResourceList{},
-			mc: limitrange.Config{
+			mc: &limitrange.Config{
 				HasDefaultLimit:         true,
 				HasMaxLimitRequestRatio: true,
 				DefaultLimit:            resource.MustParse("50Mi"),


### PR DESCRIPTION
User pointers here to match the LimitRanger interface return types. 

Nil checking happens at the pts mutator's Mutate entry point. 