### PR TITLE
Feature handler limitranger

### DIFF
--- a/internal/admission/admission.go
+++ b/internal/admission/admission.go
@@ -12,7 +12,7 @@ import (
 
 type LimitRangeContextType string
 
-const LimitRangeContextTypeMemory = "memory"
+const LimitRangeContextTypeMemory LimitRangeContextType = "memory"
 
 type AdmissionHandler interface {
 	admission.Handler

--- a/internal/admission/admission.go
+++ b/internal/admission/admission.go
@@ -10,6 +10,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
+type LimitRangeContextType string
+
+const LimitRangeContextTypeMemory = "memory"
+
 type AdmissionHandler interface {
 	admission.Handler
 	Kind() string
@@ -31,12 +35,14 @@ func WithAdmissionHandlers(handlers ...AdmissionHandler) OptionsFunc {
 }
 
 type Router struct {
-	handlers map[string]AdmissionHandler
+	handlers    map[string]AdmissionHandler
+	limitRanger LimitRanger
 }
 
-func NewRouter(opts ...OptionsFunc) (*Router, error) {
+func NewRouter(lr LimitRanger, opts ...OptionsFunc) (*Router, error) {
 	r := &Router{
-		handlers: map[string]AdmissionHandler{},
+		handlers:    map[string]AdmissionHandler{},
+		limitRanger: lr,
 	}
 
 	for _, opt := range opts {
@@ -65,9 +71,20 @@ func (r *Router) InjectDecoder(d *admission.Decoder) error {
 }
 
 func (r *Router) Handle(ctx context.Context, req admission.Request) admission.Response {
-	if h, ok := r.handlers[req.RequestKind.Kind]; ok {
-		return h.Handle(ctx, req)
+	h, ok := r.handlers[req.RequestKind.Kind]
+	if !ok {
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("resource %s not implemented", req.RequestKind.Kind))
 	}
 
-	return admission.Errored(http.StatusBadRequest, fmt.Errorf("resource %s not implemented", req.RequestKind.Kind))
+	cfg, err := r.limitRanger.LimitRangeConfig(req.Namespace)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("failed to retrieve limit range information from namespace %s: %s", req.Namespace, err.Error()))
+	}
+
+	if cfg == nil {
+		return admission.Allowed(fmt.Sprintf("No container limit range in namespace: %s", req.Namespace))
+	}
+
+	ctx = context.WithValue(ctx, LimitRangeContextTypeMemory, cfg)
+	return h.Handle(ctx, req)
 }

--- a/internal/admission/admission_test.go
+++ b/internal/admission/admission_test.go
@@ -13,11 +13,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/admission/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	corev1Listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -37,13 +34,6 @@ func (mlr *MockLimitRanger) SetConfig(lrc *limitrange.Config) {
 
 func (mlr *MockLimitRanger) SetErr(err error) {
 	mlr.err = err
-}
-
-func (mlr *MockLimitRanger) List(selector labels.Selector) (ret []*corev1.LimitRange, err error) {
-	return
-}
-func (mlr *MockLimitRanger) LimitRanges(namespace string) corev1Listers.LimitRangeNamespaceLister {
-	return nil
 }
 
 func (mlr *MockLimitRanger) LimitRangeConfig(namespace string) (*limitrange.Config, error) {

--- a/internal/admission/limitrange.go
+++ b/internal/admission/limitrange.go
@@ -2,10 +2,8 @@ package admission
 
 import (
 	"github.com/kanopy-platform/hedgetrimmer/internal/limitrange"
-	corev1Listers "k8s.io/client-go/listers/core/v1"
 )
 
 type LimitRanger interface {
-	corev1Listers.LimitRangeLister
 	LimitRangeConfig(namespace string) (*limitrange.Config, error)
 }


### PR DESCRIPTION
Makes the LimitRanger and sourcing the limit range config a top level handler concern and passes the needed limit range context to the child handlers as part of the context since Handle is an interface signature. 