### PR TITLE
Refactor common handler

### DIFF
--- a/internal/admission/admission_test.go
+++ b/internal/admission/admission_test.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/kanopy-platform/hedgetrimmer/pkg/admission/handlers"
+	"github.com/kanopy-platform/hedgetrimmer/pkg/admission/handlers/common"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/admission/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -150,7 +150,8 @@ func TestAllowObjects(t *testing.T) {
 }
 
 type MockDeploymentHandler struct {
-	handlers.DefaultHandler
+	common.Decode
+	common.Patch
 }
 
 func (d *MockDeploymentHandler) Kind() string {
@@ -176,7 +177,8 @@ func (d *MockDeploymentHandler) mutate(dp *appsv1.Deployment) *appsv1.Deployment
 }
 
 type MockReplicaSetHandler struct {
-	handlers.DefaultHandler
+	common.Decode
+	common.Patch
 }
 
 func (r *MockReplicaSetHandler) Kind() string {

--- a/pkg/admission/handlers/common/decode.go
+++ b/pkg/admission/handlers/common/decode.go
@@ -1,0 +1,19 @@
+package common
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type Decode struct {
+	Decoder *admission.Decoder
+}
+
+func (d *Decode) InjectDecoder(decoder *admission.Decoder) error {
+	if decoder == nil {
+		return fmt.Errorf("decoder cannot be nil")
+	}
+	d.Decoder = decoder
+	return nil
+}

--- a/pkg/admission/handlers/common/decode_test.go
+++ b/pkg/admission/handlers/common/decode_test.go
@@ -1,0 +1,24 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func TestInjectDecoder_FailsOnNil(t *testing.T) {
+	t.Parallel()
+	h := &Decode{}
+	assert.Error(t, h.InjectDecoder(nil))
+}
+
+func TestInjectDecoder(t *testing.T) {
+	t.Parallel()
+	h := &Decode{}
+	scheme := runtime.NewScheme()
+	decoder, err := admission.NewDecoder(scheme)
+	assert.NoError(t, err)
+	assert.NoError(t, h.InjectDecoder(decoder))
+}

--- a/pkg/admission/handlers/common/patch.go
+++ b/pkg/admission/handlers/common/patch.go
@@ -1,0 +1,19 @@
+package common
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type Patch struct{}
+
+func (p *Patch) PatchResponse(raw []byte, v interface{}) admission.Response {
+	pjson, err := json.Marshal(v)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	return admission.PatchResponseFromRaw(raw, pjson)
+}

--- a/pkg/admission/handlers/common/patch_test.go
+++ b/pkg/admission/handlers/common/patch_test.go
@@ -1,0 +1,24 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPatchResponse_ErrorsOnNil(t *testing.T) {
+	p := &Patch{}
+	resp := p.PatchResponse([]byte{}, "not json")
+	assert.Equal(t, false, resp.Allowed)
+}
+
+func TestPatchResponse_OK(t *testing.T) {
+	p := &Patch{}
+	d := struct {
+		Hello string
+	}{
+		Hello: "world",
+	}
+	resp := p.PatchResponse([]byte("{}"), &d)
+	assert.Equal(t, true, resp.Allowed)
+}

--- a/pkg/admission/handlers/default.go
+++ b/pkg/admission/handlers/default.go
@@ -2,15 +2,16 @@ package handlers
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 
+	"github.com/kanopy-platform/hedgetrimmer/pkg/admission/handlers/common"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 type DefaultHandler struct {
-	Decoder *admission.Decoder
+	common.Decode
+	common.Patch
 }
 
 func (dh *DefaultHandler) Kind() string {
@@ -19,21 +20,4 @@ func (dh *DefaultHandler) Kind() string {
 
 func (dh *DefaultHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
 	return admission.Errored(http.StatusBadRequest, fmt.Errorf("resource %s not implemented", dh.Kind()))
-}
-
-func (dh *DefaultHandler) InjectDecoder(d *admission.Decoder) error {
-	if d == nil {
-		return fmt.Errorf("decoder cannot be nil")
-	}
-	dh.Decoder = d
-	return nil
-}
-
-func (dh *DefaultHandler) PatchResponse(raw []byte, v interface{}) admission.Response {
-	pjson, err := json.Marshal(v)
-	if err != nil {
-		return admission.Errored(http.StatusBadRequest, err)
-	}
-
-	return admission.PatchResponseFromRaw(raw, pjson)
 }

--- a/pkg/admission/handlers/default_test.go
+++ b/pkg/admission/handlers/default_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -13,34 +12,4 @@ func TestDefaultHandler_HandleNotImplemented(t *testing.T) {
 	h := &DefaultHandler{}
 	r := h.Handle(context.TODO(), admission.Request{})
 	assert.False(t, r.Allowed)
-}
-
-func TestDefaultHandler_InjectDecoder_FailsOnNil(t *testing.T) {
-	h := &DefaultHandler{}
-	assert.Error(t, h.InjectDecoder(nil))
-}
-
-func TestDefaultHandler_InjectDecoder(t *testing.T) {
-	h := &DefaultHandler{}
-	scheme := runtime.NewScheme()
-	decoder, err := admission.NewDecoder(scheme)
-	assert.NoError(t, err)
-	assert.NoError(t, h.InjectDecoder(decoder))
-}
-
-func TestDefaultHandler_PatchResponse_ErrorsOnNil(t *testing.T) {
-	h := &DefaultHandler{}
-	resp := h.PatchResponse([]byte{}, "not json")
-	assert.Equal(t, false, resp.Allowed)
-}
-
-func TestDefaultHandler_PatchResponse_OK(t *testing.T) {
-	h := &DefaultHandler{}
-	d := struct {
-		Hello string
-	}{
-		Hello: "world",
-	}
-	resp := h.PatchResponse([]byte("{}"), &d)
-	assert.Equal(t, true, resp.Allowed)
 }


### PR DESCRIPTION
This is an attempt to refactor out the common parts of a handler:
- Decoder *admission.Decoder
- func InjectDecoder
- func PatchResponse

All Handlers will need these, so they can add them via composition. Instead of including `DefaultHandler` as done currently.
```
type DefaultHandler struct {
	common.Decode
	common.Patch
}
```

Not sure if this makes it more idiomatic Go