### PR TITLE
Bugfix lr informer

### DIFF
--- a/examples/k8s/deployment.yaml
+++ b/examples/k8s/deployment.yaml
@@ -126,5 +126,5 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
-    - deployments
+    - statefulsets
     scope: "Namespaced"

--- a/examples/k8s/rolebindings.yaml
+++ b/examples/k8s/rolebindings.yaml
@@ -8,6 +8,7 @@ rules:
   - apps
   resources:
   - deployments
+  - statefulset
   verbs:
   - get
   - list


### PR DESCRIPTION
This fixes the cache for the limitrange informer by adding a stubbed event listener.

It also fixes the skaffold config for the time being. 

You can test with skaffold dev against minikube and applying the test manifest


```
---
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: sleepy
  namespace: devops
spec:
  selector:
    matchLabels:
      app: nginx # has to match .spec.template.metadata.labels
  serviceName: "sleepy"
  replicas: 1 # by default is 1
  template:
    metadata:
      labels:
        app: nginx # has to match .spec.selector.matchLabels
    spec:
      containers:
      - name: sleepy
        image: ubuntu:focal
        imagePullPolicy: IfNotPresent
        command: ['/bin/sh']
        args:
          - 'c'
          - 'sleep 10'
```

