### PR TITLE
DEVOPS-3434 kind version routing support

### DIFF
--- a/internal/admission/admission.go
+++ b/internal/admission/admission.go
@@ -80,8 +80,8 @@ func (r *Router) Handle(ctx context.Context, req admission.Request) admission.Re
 		return admission.Allowed(fmt.Sprintf("no handlers for kind: %s", kind.Kind))
 	}
 
-	var h AdmissionHandler
-	for _, handler := range handlers {
+	var handler AdmissionHandler
+	for _, h := range handlers {
 		if handler.VersionSupported(kind.Version) {
 			h = handler
 			break

--- a/internal/admission/admission.go
+++ b/internal/admission/admission.go
@@ -14,6 +14,7 @@ import (
 type AdmissionHandler interface {
 	admission.Handler
 	Kind() string
+	VersionSupported(v string) bool
 	InjectDecoder(*admission.Decoder) error
 }
 
@@ -22,23 +23,21 @@ type OptionsFunc func(*Router) error
 func WithAdmissionHandlers(handlers ...AdmissionHandler) OptionsFunc {
 	return func(r *Router) error {
 		for _, h := range handlers {
-			if _, ok := r.handlers[h.Kind()]; ok {
-				return fmt.Errorf("duplicate handler %s registered", h.Kind())
-			}
-			r.handlers[h.Kind()] = h
+			handlers := r.handlers[h.Kind()]
+			r.handlers[h.Kind()] = append(handlers, h)
 		}
 		return nil
 	}
 }
 
 type Router struct {
-	handlers    map[string]AdmissionHandler
+	handlers    map[string][]AdmissionHandler
 	limitRanger LimitRanger
 }
 
 func NewRouter(lr LimitRanger, opts ...OptionsFunc) (*Router, error) {
 	r := &Router{
-		handlers:    map[string]AdmissionHandler{},
+		handlers:    map[string][]AdmissionHandler{},
 		limitRanger: lr,
 	}
 
@@ -59,18 +58,38 @@ func (r *Router) InjectDecoder(d *admission.Decoder) error {
 	if d == nil {
 		return fmt.Errorf("decoder cannot be nil")
 	}
-	for _, h := range r.handlers {
-		if err := h.InjectDecoder(d); err != nil {
-			return err
+	for _, hs := range r.handlers {
+		for _, h := range hs {
+			if err := h.InjectDecoder(d); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
 }
 
 func (r *Router) Handle(ctx context.Context, req admission.Request) admission.Response {
-	h, ok := r.handlers[req.RequestKind.Kind]
+
+	kind := req.RequestKind
+	if kind == nil {
+		kind = &req.Kind
+	}
+
+	handlers, ok := r.handlers[kind.Kind]
 	if !ok {
-		return admission.Errored(http.StatusBadRequest, fmt.Errorf("resource %s not implemented", req.RequestKind.Kind))
+		return admission.Allowed(fmt.Sprintf("no handlers for kind: %s", kind.Kind))
+	}
+
+	var h AdmissionHandler
+	for _, handler := range handlers {
+		if handler.VersionSupported(kind.Version) {
+			h = handler
+			break
+		}
+	}
+
+	if h == nil {
+		return admission.Denied(fmt.Sprintf("no handlers for %s version %s", kind.Kind, kind.Version))
 	}
 
 	cfg, err := r.limitRanger.LimitRangeConfig(req.Namespace)

--- a/internal/admission/admission.go
+++ b/internal/admission/admission.go
@@ -82,13 +82,13 @@ func (r *Router) Handle(ctx context.Context, req admission.Request) admission.Re
 
 	var handler AdmissionHandler
 	for _, h := range handlers {
-		if handler.VersionSupported(kind.Version) {
-			h = handler
+		if h.VersionSupported(kind.Version) {
+			handler = h
 			break
 		}
 	}
 
-	if h == nil {
+	if handler == nil {
 		return admission.Denied(fmt.Sprintf("no handlers for %s version %s", kind.Kind, kind.Version))
 	}
 
@@ -102,5 +102,5 @@ func (r *Router) Handle(ctx context.Context, req admission.Request) admission.Re
 	}
 
 	ctx = limitrange.WithMemoryConfig(ctx, cfg)
-	return h.Handle(ctx, req)
+	return handler.Handle(ctx, req)
 }

--- a/pkg/admission/handlers/cronjob.go
+++ b/pkg/admission/handlers/cronjob.go
@@ -15,6 +15,7 @@ import (
 
 type CronjobHandler struct {
 	DefaultDecoderInjector
+	AllVersionSupporter
 	ptm admission.PodTemplateSpecMutator
 }
 

--- a/pkg/admission/handlers/default.go
+++ b/pkg/admission/handlers/default.go
@@ -12,6 +12,12 @@ type DefaultDecoderInjector struct {
 	decoder *admission.Decoder
 }
 
+type AllVersionSupporter struct{}
+
+func (s *AllVersionSupporter) VersionSupported(v string) bool {
+	return true
+}
+
 func (d *DefaultDecoderInjector) InjectDecoder(decoder *admission.Decoder) error {
 	if decoder == nil {
 		return fmt.Errorf("decoder cannot be nil")

--- a/pkg/admission/handlers/deployment.go
+++ b/pkg/admission/handlers/deployment.go
@@ -14,6 +14,7 @@ import (
 
 type DeploymentHandler struct {
 	DefaultDecoderInjector
+	AllVersionSupporter
 	ptm admission.PodTemplateSpecMutator
 }
 

--- a/pkg/admission/handlers/job.go
+++ b/pkg/admission/handlers/job.go
@@ -15,6 +15,7 @@ import (
 
 type JobHandler struct {
 	DefaultDecoderInjector
+	AllVersionSupporter
 	ptm admission.PodTemplateSpecMutator
 }
 

--- a/pkg/admission/handlers/sts.go
+++ b/pkg/admission/handlers/sts.go
@@ -14,6 +14,7 @@ import (
 
 type StatefulSetHandler struct {
 	DefaultDecoderInjector
+	AllVersionSupporter
 	ptm admission.PodTemplateSpecMutator
 }
 


### PR DESCRIPTION
This adds version support in the router and adds a new interface method for AdmissionHandlers, VersionSupported. I have added in a functional "*" version supporter since we don't currently need to split Handle for different kind versions. 

This changes a little bit of behavior from before. If the controller receives a Kind that it has no handlers for, it will allow the request in unchanged. If the controller receives a kind that it has handlers for but on a version it doesn't support, it will deny the request.

