### PR TITLE
ReplicaSet handler

### DIFF
--- a/examples/k8s/deployment.yaml
+++ b/examples/k8s/deployment.yaml
@@ -128,6 +128,7 @@ webhooks:
     resources:
     - statefulsets
     - deployments
+    - replicasets
     scope: "Namespaced"
   - apiGroups:
     - batch

--- a/examples/k8s/rolebindings.yaml
+++ b/examples/k8s/rolebindings.yaml
@@ -9,6 +9,7 @@ rules:
   resources:
   - deployments
   - statefulset
+  - replicasets
   verbs:
   - get
   - list

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -138,6 +138,7 @@ func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {
 			handlers.NewCronjobHandler(ptm),
 			handlers.NewJobHandler(ptm),
 			handlers.NewReplicationControllerHandler(ptm),
+			handlers.NewReplicaSetHandler(ptm),
 		))
 	if err != nil {
 		return err

--- a/pkg/admission/handlers/replicaset_test.go
+++ b/pkg/admission/handlers/replicaset_test.go
@@ -1,0 +1,31 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestReplicaSetHandler(t *testing.T) {
+	t.Parallel()
+	mutator := &MockMutator{}
+
+	scheme := runtime.NewScheme()
+	decoder := assertDecoder(t, scheme)
+
+	handler := NewReplicaSetHandler(mutator)
+	assert.NoError(t, handler.InjectDecoder(decoder))
+
+	r := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-replicaset",
+			Namespace: "test-ns",
+		},
+		Spec: appsv1.ReplicaSetSpec{},
+	}
+
+	testHandler(t, r, mutator, handler)
+}


### PR DESCRIPTION
**Testing**
Start minikube
`skaffold dev`

Apply the following
```
apiVersion: apps/v1
kind: ReplicaSet
metadata:
  name: test-replicaset
spec:
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
        - containerPort: 80
        resources:
          requests:
            memory: "50Mi"
```

`kubectl describe rs test-replicaset` shows the `Limits.memory` is set to `55Mi` as expected and hedgetrimmer logs shows mutation occurred.