### PR TITLE
DaemonSet handler

### DIFF
--- a/examples/k8s/deployment.yaml
+++ b/examples/k8s/deployment.yaml
@@ -129,6 +129,7 @@ webhooks:
     - statefulsets
     - deployments
     - replicasets
+    - daemonsets
     scope: "Namespaced"
   - apiGroups:
     - batch

--- a/examples/k8s/rolebindings.yaml
+++ b/examples/k8s/rolebindings.yaml
@@ -10,6 +10,7 @@ rules:
   - deployments
   - statefulset
   - replicasets
+  - daemonsets
   verbs:
   - get
   - list

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -139,6 +139,7 @@ func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {
 			handlers.NewJobHandler(ptm),
 			handlers.NewReplicationControllerHandler(ptm),
 			handlers.NewReplicaSetHandler(ptm),
+			handlers.NewDaemonSetHandler(ptm),
 		))
 	if err != nil {
 		return err

--- a/pkg/admission/handlers/daemonset.go
+++ b/pkg/admission/handlers/daemonset.go
@@ -1,0 +1,56 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/kanopy-platform/hedgetrimmer/pkg/admission"
+	"github.com/kanopy-platform/hedgetrimmer/pkg/limitrange"
+	kadmission "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type DaemonSetHandler struct {
+	DefaultDecoderInjector
+	AllVersionSupporter
+	ptm admission.PodTemplateSpecMutator
+}
+
+func NewDaemonSetHandler(ptm admission.PodTemplateSpecMutator) *DaemonSetHandler {
+	return &DaemonSetHandler{ptm: ptm}
+}
+
+func (d *DaemonSetHandler) Kind() string {
+	return "DaemonSet"
+}
+
+func (d *DaemonSetHandler) Handle(ctx context.Context, req kadmission.Request) kadmission.Response {
+	log := log.FromContext(ctx)
+
+	lrConfig, err := limitrange.MemoryConfigFromContext(ctx)
+	if err != nil {
+		reason := fmt.Sprintf("invalid LimitRange config for namespace: %s", req.Namespace)
+		log.Error(err, reason)
+		return kadmission.Denied(reason)
+	}
+
+	out := &appsv1.DaemonSet{}
+	if err := d.decoder.Decode(req, out); err != nil {
+		log.Error(err, "failed to decode DaemonSet request: %s", req.Name)
+		return kadmission.Errored(http.StatusBadRequest, err)
+	}
+
+	pts, err := d.ptm.Mutate(out.Spec.Template, lrConfig)
+	if err != nil {
+		reason := fmt.Sprintf("failed to mutate DaemonSet %s/%s: %s", out.Namespace, out.Name, err)
+		log.Error(err, reason)
+		return kadmission.Denied(reason)
+	}
+
+	out.Spec.Template = pts
+
+	return PatchResponse(req.Object.Raw, out)
+}

--- a/pkg/admission/handlers/daemonset_test.go
+++ b/pkg/admission/handlers/daemonset_test.go
@@ -1,0 +1,31 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestDaemonSetHandler(t *testing.T) {
+	t.Parallel()
+	mutator := &MockMutator{}
+
+	scheme := runtime.NewScheme()
+	decoder := assertDecoder(t, scheme)
+
+	handler := NewDaemonSetHandler(mutator)
+	assert.NoError(t, handler.InjectDecoder(decoder))
+
+	d := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-daemonset",
+			Namespace: "test-ns",
+		},
+		Spec: appsv1.DaemonSetSpec{},
+	}
+
+	testHandler(t, d, mutator, handler)
+}


### PR DESCRIPTION
**Testing**
Start minikube
`skaffold dev`

Apply the following
```
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: test-daemonset
spec:
  selector:
    matchLabels:
      name: test-daemonset
  template:
    metadata:
      labels:
        name: test-daemonset
    spec:
      containers:
      - name: nginx
        image: nginx:1.14.2
        resources:
          requests:
            cpu: 100m
            memory: 100Mi
```

`kubectl describe ds test-daemonset` shows Limits.memory is set to `110Mi` as expected, and hedgetrimmer logs show mutation occurred.