### PR TITLE
DEVOPS-3372 pod handler

### DIFF
--- a/examples/k8s/deployment.yaml
+++ b/examples/k8s/deployment.yaml
@@ -151,4 +151,5 @@ webhooks:
     - UPDATE
     resources:
     - replicationcontrollers
+    - pods
     scope: "Namespaced"

--- a/examples/k8s/rolebindings.yaml
+++ b/examples/k8s/rolebindings.yaml
@@ -46,6 +46,16 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/examples/k8s/rolebindings.yaml
+++ b/examples/k8s/rolebindings.yaml
@@ -32,6 +32,7 @@ rules:
   - ""
   resources:
   - replicationcontrollers
+  - pods
   verbs:
   - get
   - list
@@ -45,16 +46,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - patch
-  - update
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -140,6 +140,7 @@ func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {
 			handlers.NewReplicationControllerHandler(ptm),
 			handlers.NewReplicaSetHandler(ptm),
 			handlers.NewDaemonSetHandler(ptm),
+			handlers.NewPodHandler(ptm),
 		))
 	if err != nil {
 		return err

--- a/pkg/admission/handlers/pod.go
+++ b/pkg/admission/handlers/pod.go
@@ -1,0 +1,66 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/kanopy-platform/hedgetrimmer/pkg/admission"
+	"github.com/kanopy-platform/hedgetrimmer/pkg/limitrange"
+	kadmission "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type PodHandler struct {
+	DefaultDecoderInjector
+	ptm admission.PodTemplateSpecMutator
+}
+
+func NewPodHandler(ptm admission.PodTemplateSpecMutator) *PodHandler {
+	return &PodHandler{ptm: ptm}
+}
+
+func (p *PodHandler) Kind() string {
+	return "Pod"
+}
+
+func (p *PodHandler) Handle(ctx context.Context, req kadmission.Request) kadmission.Response {
+	log := log.FromContext(ctx)
+
+	if req.Operation != admissionv1.Create {
+		fmt.Println(req.Operation)
+		return kadmission.Allowed("pod resources are immutable")
+	}
+
+	lrConfig, err := limitrange.MemoryConfigFromContext(ctx)
+	if err != nil {
+		reason := fmt.Sprintf("invalid LimitRange config for namespace: %s", req.Namespace)
+		log.Error(err, reason)
+		return kadmission.Denied(reason)
+	}
+
+	out := corev1.Pod{}
+	if err := p.decoder.Decode(req, &out); err != nil {
+		log.Error(err, "failed to decode request: %s", req.Name)
+		return kadmission.Errored(http.StatusBadRequest, err)
+	}
+
+	//Shove the PodSpec into a PTS to leverage the existing mutator
+	mout := corev1.PodTemplateSpec{
+		Spec: out.Spec,
+	}
+
+	pts, err := p.ptm.Mutate(mout, lrConfig)
+	if err != nil {
+		reason := fmt.Sprintf("failed to mutate pod %s/%s: %s", out.Namespace, out.Name, err)
+		log.Error(err, reason)
+		return kadmission.Denied(reason)
+	}
+
+	//Pull the mutated spec off of the PTS and replace the Pod.Spec with it
+	out.Spec = pts.Spec
+	return PatchResponse(req.Object.Raw, &out)
+}

--- a/pkg/admission/handlers/pod.go
+++ b/pkg/admission/handlers/pod.go
@@ -32,7 +32,6 @@ func (p *PodHandler) Handle(ctx context.Context, req kadmission.Request) kadmiss
 	log := log.FromContext(ctx)
 
 	if req.Operation != admissionv1.Create {
-		fmt.Println(req.Operation)
 		return kadmission.Allowed("pod resources are immutable")
 	}
 

--- a/pkg/admission/handlers/pod.go
+++ b/pkg/admission/handlers/pod.go
@@ -16,6 +16,7 @@ import (
 
 type PodHandler struct {
 	DefaultDecoderInjector
+	AllVersionSupporter
 	ptm admission.PodTemplateSpecMutator
 }
 

--- a/pkg/admission/handlers/pod_test.go
+++ b/pkg/admission/handlers/pod_test.go
@@ -1,0 +1,81 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/kanopy-platform/hedgetrimmer/pkg/limitrange"
+	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func TestPodHandler(t *testing.T) {
+	t.Parallel()
+	mutator := &MockMutator{}
+
+	scheme := runtime.NewScheme()
+	decoder := assertDecoder(t, scheme)
+
+	handler := NewPodHandler(mutator)
+	assert.NoError(t, handler.InjectDecoder(decoder))
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cronjob",
+			Namespace: "test-ns",
+		},
+		Spec: corev1.PodSpec{},
+	}
+	bytes, err := json.Marshal(pod)
+	assert.NoError(t, err)
+
+	ar := admissionv1.AdmissionRequest{
+		Object: runtime.RawExtension{
+			Raw: bytes,
+		},
+		Operation: admissionv1.Create,
+	}
+
+	tests := []struct {
+		config  *limitrange.Config
+		lrerr   error
+		pts     corev1.PodTemplateSpec
+		merr    error
+		reject  bool
+		msg     string
+		mutated bool
+	}{
+		{
+			reject: true,
+			config: &limitrange.Config{},
+			merr:   fmt.Errorf("Fail"),
+			msg:    "Reject for failed mutation",
+		},
+		{
+			config: &limitrange.Config{},
+			pts: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					NodeName: "mutated",
+				},
+			},
+			msg:     "Allow for a namespace with no limitranges",
+			mutated: true,
+		},
+	}
+
+	for _, test := range tests {
+		mutator.SetSpec(test.pts)
+		mutator.SetErr(test.merr)
+		ctx := context.WithValue(context.Background(), limitrange.LimitRangeContextTypeMemory, test.config)
+
+		resp := handler.Handle(ctx, admission.Request{AdmissionRequest: ar})
+		assert.Equal(t, test.reject, !resp.Allowed, test.msg)
+		assert.Equal(t, test.mutated, len(resp.Patches) > 0)
+	}
+}

--- a/pkg/admission/handlers/pod_test.go
+++ b/pkg/admission/handlers/pod_test.go
@@ -44,7 +44,6 @@ func TestPodHandler(t *testing.T) {
 
 	tests := []struct {
 		config  *limitrange.Config
-		lrerr   error
 		pts     corev1.PodTemplateSpec
 		merr    error
 		reject  bool


### PR DESCRIPTION
This leverages the existing mutator to mutate pods.

Tests are custom because the pod template spec metadata isn't used. 