### PR TITLE
Add CLI options

### DIFF
--- a/examples/k8s/deployment.yaml
+++ b/examples/k8s/deployment.yaml
@@ -40,6 +40,8 @@ spec:
           image: registry.example.com/hedgetrimmer:latest
           args:
             - "--log-level=debug"
+            - "--default-memory-limit-request-ratio=2"
+            - "--resources=cronjobs,daemonsets,deployments,jobs,replicasets,replicationcontrollers,statefulsets"
           imagePullPolicy: Always
           volumeMounts:
             - name: webhook-certs

--- a/examples/k8s/deployment.yaml
+++ b/examples/k8s/deployment.yaml
@@ -40,8 +40,8 @@ spec:
           image: registry.example.com/hedgetrimmer:latest
           args:
             - "--log-level=debug"
-            - "--default-memory-limit-request-ratio=2"
-            - "--resources=cronjobs,daemonsets,deployments,jobs,replicasets,replicationcontrollers,statefulsets"
+            - "--default-memory-limit-request-ratio=1.1"
+            - "--resources=cronjobs,daemonsets,deployments,jobs,pods,replicasets,replicationcontrollers,statefulsets"
           imagePullPolicy: Always
           volumeMounts:
             - name: webhook-certs

--- a/examples/k8s/deployment.yaml
+++ b/examples/k8s/deployment.yaml
@@ -41,7 +41,6 @@ spec:
           args:
             - "--log-level=debug"
             - "--default-memory-limit-request-ratio=1.1"
-            - "--resources=cronjobs,daemonsets,deployments,jobs,pods,replicasets,replicationcontrollers,statefulsets"
           imagePullPolicy: Always
           volumeMounts:
             - name: webhook-certs

--- a/examples/k8s/deployment.yaml
+++ b/examples/k8s/deployment.yaml
@@ -40,7 +40,6 @@ spec:
           image: registry.example.com/hedgetrimmer:latest
           args:
             - "--log-level=debug"
-            - "--default-memory-limit-request-ratio=1.1"
           imagePullPolicy: Always
           volumeMounts:
             - name: webhook-certs

--- a/examples/k8s/rolebindings.yaml
+++ b/examples/k8s/rolebindings.yaml
@@ -8,7 +8,7 @@ rules:
   - apps
   resources:
   - deployments
-  - statefulset
+  - statefulsets
   - replicasets
   - daemonsets
   verbs:
@@ -71,14 +71,11 @@ rules:
   - ""
   resources:
   - events
-  - configmaps
   verbs:
   - create
   - get
   - list
   - update
-  - patch
-  - delete
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -188,6 +188,8 @@ func getHandlers(resources string, ptm pkgadmission.PodTemplateSpecMutator) ([]a
 			handlers = append(handlers, pkghandlers.NewDeploymentHandler(ptm))
 		case "jobs":
 			handlers = append(handlers, pkghandlers.NewJobHandler(ptm))
+		case "pods":
+			handlers = append(handlers, pkghandlers.NewPodHandler(ptm))
 		case "replicasets":
 			handlers = append(handlers, pkghandlers.NewReplicaSetHandler(ptm))
 		case "replicationcontrollers":

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -12,7 +13,8 @@ import (
 
 	"github.com/kanopy-platform/hedgetrimmer/internal/admission"
 	logzap "github.com/kanopy-platform/hedgetrimmer/internal/log/zap"
-	"github.com/kanopy-platform/hedgetrimmer/pkg/admission/handlers"
+	pkgadmission "github.com/kanopy-platform/hedgetrimmer/pkg/admission"
+	pkghandlers "github.com/kanopy-platform/hedgetrimmer/pkg/admission/handlers"
 	"github.com/kanopy-platform/hedgetrimmer/pkg/limitrange"
 	"github.com/kanopy-platform/hedgetrimmer/pkg/mutators"
 
@@ -49,6 +51,8 @@ func NewRootCommand() *cobra.Command {
 	cmd.PersistentFlags().Int("webhook-listen-port", 8443, "Admission webhook listen port")
 	cmd.PersistentFlags().String("webhook-certs-dir", "/etc/webhook/certs", "Admission webhook TLS certificate directory")
 	cmd.PersistentFlags().Bool("dry-run", false, "Controller dry-run changes only")
+	cmd.PersistentFlags().Float64("default-memory-limit-request-ratio", 1.1, "Default memory limit/request ratio")
+	cmd.PersistentFlags().String("resources", "", "Comma separated list of resources to enforce")
 
 	k8sFlags.AddFlags(cmd.PersistentFlags())
 	// no need to check err, this only checks if variadic args != 0
@@ -129,19 +133,18 @@ func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {
 
 	limitRanger := limitrange.NewLimitRanger(lri.Lister())
 
-	ptm := mutators.NewPodTemplateSpec()
+	ptm := mutators.NewPodTemplateSpec(
+		mutators.WithDefaultMemoryLimitRequestRatio(viper.GetFloat64("default-memory-limit-request-ratio")),
+	)
+
+	handlers, err := getHandlers(viper.GetString("resources"), ptm)
+	if err != nil {
+		return err
+	}
 
 	admissionRouter, err := admission.NewRouter(limitRanger,
-		admission.WithAdmissionHandlers(
-			handlers.NewStatefulSetHandler(ptm),
-			handlers.NewDeploymentHandler(ptm),
-			handlers.NewCronjobHandler(ptm),
-			handlers.NewJobHandler(ptm),
-			handlers.NewReplicationControllerHandler(ptm),
-			handlers.NewReplicaSetHandler(ptm),
-			handlers.NewDaemonSetHandler(ptm),
-			handlers.NewPodHandler(ptm),
-		))
+		admission.WithAdmissionHandlers(handlers...),
+	)
 	if err != nil {
 		return err
 	}
@@ -160,4 +163,45 @@ func configureHealthChecks(mgr manager.Manager) error {
 		return err
 	}
 	return nil
+}
+
+func getHandlers(resources string, ptm pkgadmission.PodTemplateSpecMutator) ([]admission.AdmissionHandler, error) {
+	var handlers []admission.AdmissionHandler
+	var unexpected []string
+
+	if len(resources) == 0 {
+		return handlers, nil
+	}
+
+	dedupedResources := make(map[string]bool)
+	for _, resource := range strings.Split(resources, ",") {
+		dedupedResources[strings.TrimSpace(resource)] = true
+	}
+
+	for resource := range dedupedResources {
+		switch resource {
+		case "cronjobs":
+			handlers = append(handlers, pkghandlers.NewCronjobHandler(ptm))
+		case "daemonsets":
+			handlers = append(handlers, pkghandlers.NewDaemonSetHandler(ptm))
+		case "deployments":
+			handlers = append(handlers, pkghandlers.NewDeploymentHandler(ptm))
+		case "jobs":
+			handlers = append(handlers, pkghandlers.NewJobHandler(ptm))
+		case "replicasets":
+			handlers = append(handlers, pkghandlers.NewReplicaSetHandler(ptm))
+		case "replicationcontrollers":
+			handlers = append(handlers, pkghandlers.NewReplicationControllerHandler(ptm))
+		case "statefulsets":
+			handlers = append(handlers, pkghandlers.NewStatefulSetHandler(ptm))
+		default:
+			unexpected = append(unexpected, resource)
+		}
+	}
+
+	if len(unexpected) > 0 {
+		return []admission.AdmissionHandler{}, fmt.Errorf("unexpected resources: %v", unexpected)
+	}
+
+	return handlers, nil
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -13,37 +13,37 @@ func TestGetHandlers(t *testing.T) {
 
 	tests := []struct {
 		msg       string
-		resources string
+		resources []string
 		wantLen   int
 		wantError bool
 	}{
 		{
 			msg:       "Full list of resources",
-			resources: "cronjobs,daemonsets,deployments,jobs,pods,replicasets,replicationcontrollers,statefulsets",
+			resources: all_resources,
 			wantLen:   8,
 			wantError: false,
 		},
 		{
 			msg:       "Unexpected resource",
-			resources: "cronjobs,unexpected",
+			resources: []string{cronjobs, "unexpected"},
 			wantLen:   0,
 			wantError: true,
 		},
 		{
-			msg:       "Handle empty resources string",
-			resources: "",
+			msg:       "Handle empty input",
+			resources: []string{},
 			wantLen:   0,
 			wantError: false,
 		},
 		{
 			msg:       "Handle leading and trailing spaces",
-			resources: " daemonsets ,  replicasets,replicationcontrollers  ",
+			resources: []string{" daemonsets ", "  replicasets", "replicationcontrollers  "},
 			wantLen:   3,
 			wantError: false,
 		},
 		{
 			msg:       "Handle duplicated resources",
-			resources: "daemonsets,replicasets,replicasets,daemonsets,replicasets",
+			resources: []string{daemonsets, replicasets, replicasets, daemonsets, replicasets},
 			wantLen:   2,
 			wantError: false,
 		},

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -19,8 +19,8 @@ func TestGetHandlers(t *testing.T) {
 	}{
 		{
 			msg:       "Full list of resources",
-			resources: "cronjobs,daemonsets,deployments,jobs,replicasets,replicationcontrollers,statefulsets",
-			wantLen:   7,
+			resources: "cronjobs,daemonsets,deployments,jobs,pods,replicasets,replicationcontrollers,statefulsets",
+			wantLen:   8,
 			wantError: false,
 		},
 		{

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/kanopy-platform/hedgetrimmer/pkg/mutators"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetHandlers(t *testing.T) {
+	t.Parallel()
+	mutator := mutators.NewPodTemplateSpec()
+
+	tests := []struct {
+		msg       string
+		resources string
+		wantLen   int
+		wantError bool
+	}{
+		{
+			msg:       "Full list of resources",
+			resources: "cronjobs,daemonsets,deployments,jobs,replicasets,replicationcontrollers,statefulsets",
+			wantLen:   7,
+			wantError: false,
+		},
+		{
+			msg:       "Unexpected resource",
+			resources: "cronjobs,unexpected",
+			wantLen:   0,
+			wantError: true,
+		},
+		{
+			msg:       "Handle empty resources string",
+			resources: "",
+			wantLen:   0,
+			wantError: false,
+		},
+		{
+			msg:       "Handle leading and trailing spaces",
+			resources: " daemonsets ,  replicasets,replicationcontrollers  ",
+			wantLen:   3,
+			wantError: false,
+		},
+		{
+			msg:       "Handle duplicated resources",
+			resources: "daemonsets,replicasets,replicasets,daemonsets,replicasets",
+			wantLen:   2,
+			wantError: false,
+		},
+	}
+
+	for _, test := range tests {
+		handlers, err := getHandlers(test.resources, mutator)
+		assert.Len(t, handlers, test.wantLen, test.msg)
+		assert.Equal(t, test.wantError, err != nil, test.msg)
+	}
+}

--- a/internal/cli/constants.go
+++ b/internal/cli/constants.go
@@ -1,0 +1,23 @@
+package cli
+
+const (
+	cronjobs               = "cronjobs"
+	daemonsets             = "daemonsets"
+	deployments            = "deployments"
+	jobs                   = "jobs"
+	pods                   = "pods"
+	replicasets            = "replicasets"
+	replicationcontrollers = "replicationcontrollers"
+	statefulsets           = "statefulsets"
+)
+
+var all_resources = []string{
+	cronjobs,
+	daemonsets,
+	deployments,
+	jobs,
+	pods,
+	replicasets,
+	replicationcontrollers,
+	statefulsets,
+}


### PR DESCRIPTION
Adding the following CLI options:
`--default-memory-limit-request-ratio`
`--resources` - a comma separated list of resources for hedgetrimmer to enforce. It creates handlers based off the resources specified here.

Minor cleanup in `rolebindings.yaml`