### PR TITLE
Fix calculated limit to be readable

### DIFF
--- a/pkg/mutators/podtemplatespec.go
+++ b/pkg/mutators/podtemplatespec.go
@@ -117,9 +117,9 @@ func (p *PodTemplateSpec) setMemoryLimit(container *corev1.Container, limitRange
 	var calculatedLimit resource.Quantity
 
 	if limitRangeMemory.HasMaxLimitRequestRatio && !memoryRequest.IsZero() {
-		calculatedLimit = quantity.Mul(*memoryRequest, limitRangeMemory.MaxLimitRequestRatio)
+		calculatedLimit = quantity.RoundUpBinarySI(quantity.Mul(*memoryRequest, limitRangeMemory.MaxLimitRequestRatio))
 	} else {
-		ratioMemoryLimit := quantity.Mul(*memoryRequest, p.defaultMemoryLimitRequestRatio)
+		ratioMemoryLimit := quantity.RoundUpBinarySI(quantity.Mul(*memoryRequest, p.defaultMemoryLimitRequestRatio))
 		calculatedLimit = quantity.Max(limitRangeMemory.DefaultLimit, ratioMemoryLimit)
 	}
 

--- a/pkg/mutators/podtemplatespec_test.go
+++ b/pkg/mutators/podtemplatespec_test.go
@@ -92,10 +92,10 @@ func TestMutate(t *testing.T) {
 				assert.NoError(t, err, test.msg)
 
 				for idx, container := range result.Spec.InitContainers {
-					request := container.Resources.Requests.Memory()
-					limit := container.Resources.Limits.Memory()
-					assert.True(t, test.want[idx].Resources.Requests.Memory().Equal(*request), test.msg)
-					assert.True(t, test.want[idx].Resources.Limits.Memory().Equal(*limit), test.msg)
+					wantRequest := test.want[idx].Resources.Requests.Memory()
+					wantLimit := test.want[idx].Resources.Limits.Memory()
+					assert.True(t, container.Resources.Requests.Memory().Equal(*wantRequest), test.msg)
+					assert.True(t, container.Resources.Limits.Memory().Equal(*wantLimit), test.msg)
 				}
 			}
 		}

--- a/pkg/quantity/constants.go
+++ b/pkg/quantity/constants.go
@@ -1,0 +1,11 @@
+package quantity
+
+import "k8s.io/apimachinery/pkg/api/resource"
+
+var (
+	One_KiB resource.Quantity = resource.MustParse("1Ki")
+	One_MiB resource.Quantity = resource.MustParse("1Mi")
+	Ten_MiB resource.Quantity = resource.MustParse("10Mi")
+	One_GiB resource.Quantity = resource.MustParse("1Gi")
+	Ten_GiB resource.Quantity = resource.MustParse("10Gi")
+)

--- a/pkg/quantity/constants.go
+++ b/pkg/quantity/constants.go
@@ -3,7 +3,7 @@ package quantity
 import "k8s.io/apimachinery/pkg/api/resource"
 
 var (
-	One_KiB resource.Quantity = resource.MustParse("1Ki")
-	One_MiB resource.Quantity = resource.MustParse("1Mi")
-	Ten_MiB resource.Quantity = resource.MustParse("10Mi")
+	OneKi resource.Quantity = resource.MustParse("1Ki")
+	OneMi resource.Quantity = resource.MustParse("1Mi")
+	TenMi resource.Quantity = resource.MustParse("10Mi")
 )

--- a/pkg/quantity/constants.go
+++ b/pkg/quantity/constants.go
@@ -6,6 +6,4 @@ var (
 	One_KiB resource.Quantity = resource.MustParse("1Ki")
 	One_MiB resource.Quantity = resource.MustParse("1Mi")
 	Ten_MiB resource.Quantity = resource.MustParse("10Mi")
-	One_GiB resource.Quantity = resource.MustParse("1Gi")
-	Ten_GiB resource.Quantity = resource.MustParse("10Gi")
 )

--- a/pkg/quantity/quantity.go
+++ b/pkg/quantity/quantity.go
@@ -86,9 +86,7 @@ func RoundUpBinarySI(q resource.Quantity) resource.Quantity {
 	qCopy := q.DeepCopy()
 
 	// Note the implementation cannot use resource.RoundUp(), it operates using DecimalSI.
-	if qCopy.Cmp(Ten_GiB) == 1 {
-		qCopy = roundUp(qCopy, One_GiB)
-	} else if qCopy.Cmp(Ten_MiB) == 1 {
+	if qCopy.Cmp(Ten_MiB) == 1 {
 		qCopy = roundUp(qCopy, One_MiB)
 	} else {
 		qCopy = roundUp(qCopy, One_KiB)

--- a/pkg/quantity/quantity.go
+++ b/pkg/quantity/quantity.go
@@ -86,10 +86,10 @@ func RoundUpBinarySI(q resource.Quantity) resource.Quantity {
 	qCopy := q.DeepCopy()
 
 	// Note the implementation cannot use resource.RoundUp(), it operates using DecimalSI.
-	if qCopy.Cmp(Ten_MiB) == 1 {
-		qCopy = roundUp(qCopy, One_MiB)
+	if qCopy.Cmp(TenMi) == 1 {
+		qCopy = roundUp(qCopy, OneMi)
 	} else {
-		qCopy = roundUp(qCopy, One_KiB)
+		qCopy = roundUp(qCopy, OneKi)
 	}
 
 	qCopy.Format = resource.BinarySI

--- a/pkg/quantity/quantity.go
+++ b/pkg/quantity/quantity.go
@@ -85,7 +85,7 @@ func Ptr(q resource.Quantity) *resource.Quantity {
 func RoundUpBinarySI(q resource.Quantity) resource.Quantity {
 	qCopy := q.DeepCopy()
 
-	// Note the implementation cannot use resource.RoundUp() because it operates using DecimalSI.
+	// Note the implementation cannot use resource.RoundUp(), it operates using DecimalSI.
 	if qCopy.Cmp(Ten_GiB) == 1 {
 		qCopy = roundUp(qCopy, One_GiB)
 	} else if qCopy.Cmp(Ten_MiB) == 1 {

--- a/pkg/quantity/quantity.go
+++ b/pkg/quantity/quantity.go
@@ -36,6 +36,8 @@ func MulFloat64(x resource.Quantity, y float64) (resource.Quantity, error) {
 	return Mul(x, yQuantity), nil
 }
 
+// Returns x/y rounded up to the specified scale s.
+// Note that inf.Scale is inverted. -2 means 100, 2 means 0.01.
 func Div(x resource.Quantity, y resource.Quantity, s inf.Scale) resource.Quantity {
 	result := resource.Quantity{}
 	result.Format = x.Format
@@ -77,4 +79,26 @@ func Max(x resource.Quantity, y resource.Quantity) resource.Quantity {
 
 func Ptr(q resource.Quantity) *resource.Quantity {
 	return &q
+}
+
+// Rounds up input q to the nearest BinarySI representation Gi/Mi/Ki.
+func RoundUpBinarySI(q resource.Quantity) resource.Quantity {
+	qCopy := q.DeepCopy()
+
+	// Note the implementation cannot use resource.RoundUp() because it operates using DecimalSI.
+	if qCopy.Cmp(Ten_GiB) == 1 {
+		qCopy = roundUp(qCopy, One_GiB)
+	} else if qCopy.Cmp(Ten_MiB) == 1 {
+		qCopy = roundUp(qCopy, One_MiB)
+	} else {
+		qCopy = roundUp(qCopy, One_KiB)
+	}
+
+	qCopy.Format = resource.BinarySI
+	return qCopy
+}
+
+// Performs integer division to round up q to the given unit.
+func roundUp(q resource.Quantity, unit resource.Quantity) resource.Quantity {
+	return Mul(Div(q, unit, 0), unit)
 }

--- a/pkg/quantity/quantity.go
+++ b/pkg/quantity/quantity.go
@@ -81,7 +81,7 @@ func Ptr(q resource.Quantity) *resource.Quantity {
 	return &q
 }
 
-// Rounds up input q to the nearest BinarySI representation Gi/Mi/Ki.
+// Rounds up input q to the nearest BinarySI representation Mi/Ki.
 func RoundUpBinarySI(q resource.Quantity) resource.Quantity {
 	qCopy := q.DeepCopy()
 

--- a/pkg/quantity/quantity_test.go
+++ b/pkg/quantity/quantity_test.go
@@ -382,6 +382,11 @@ func TestRoundUpBinarySI(t *testing.T) {
 		want  resource.Quantity
 	}{
 		{
+			msg:   "123.4Ki rounds up to 124Ki",
+			input: resource.MustParse("123.4Ki"),
+			want:  resource.MustParse("124Ki"),
+		},
+		{
 			msg:   "9.8Mi rounds up to 10036Ki",
 			input: resource.MustParse("9.8Mi"),
 			want:  resource.MustParse("10036Ki"),
@@ -390,11 +395,6 @@ func TestRoundUpBinarySI(t *testing.T) {
 			msg:   "10.1Mi rounds up to 11Mi",
 			input: resource.MustParse("10.1Mi"),
 			want:  resource.MustParse("11Mi"),
-		},
-		{
-			msg:   "12345Mi rounds up to 13Gi",
-			input: resource.MustParse("12345Mi"),
-			want:  resource.MustParse("13Gi"),
 		},
 		{
 			msg:   "15Gi no rounding",

--- a/pkg/quantity/quantity_test.go
+++ b/pkg/quantity/quantity_test.go
@@ -421,7 +421,7 @@ func TestRoundUp(t *testing.T) {
 		{
 			msg:   "1.01Ki rounded up to nearest 1Ki = 2Ki",
 			input: resource.MustParse("1.01Ki"),
-			unit:  resource.MustParse("2Ki"),
+			unit:  resource.MustParse("1Ki"),
 			want:  resource.MustParse("2Ki"),
 		},
 		{

--- a/pkg/quantity/quantity_test.go
+++ b/pkg/quantity/quantity_test.go
@@ -372,3 +372,80 @@ func TestMax(t *testing.T) {
 		assert.Equal(t, test.want, Max(test.inputA, test.inputB), test.msg)
 	}
 }
+
+func TestRoundUpBinarySI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		msg   string
+		input resource.Quantity
+		want  resource.Quantity
+	}{
+		{
+			msg:   "9.8Mi rounds up to 10036Ki",
+			input: resource.MustParse("9.8Mi"),
+			want:  resource.MustParse("10036Ki"),
+		},
+		{
+			msg:   "10.1Mi rounds up to 11Mi",
+			input: resource.MustParse("10.1Mi"),
+			want:  resource.MustParse("11Mi"),
+		},
+		{
+			msg:   "12345Mi rounds up to 13Gi",
+			input: resource.MustParse("12345Mi"),
+			want:  resource.MustParse("13Gi"),
+		},
+		{
+			msg:   "15Gi no rounding",
+			input: resource.MustParse("15Gi"),
+			want:  resource.MustParse("15Gi"),
+		},
+	}
+
+	for _, test := range tests {
+		result := RoundUpBinarySI(test.input)
+		assert.True(t, test.want.Equal(result), test.msg)
+	}
+}
+
+func TestRoundUp(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		msg   string
+		input resource.Quantity
+		unit  resource.Quantity
+		want  resource.Quantity
+	}{
+		{
+			msg:   "1.01Ki rounded up to nearest 1Ki = 2Ki",
+			input: resource.MustParse("1.01Ki"),
+			unit:  resource.MustParse("2Ki"),
+			want:  resource.MustParse("2Ki"),
+		},
+		{
+			msg:   "64Mi rounded up to nearest 1Mi = no rounding",
+			input: resource.MustParse("64Mi"),
+			unit:  resource.MustParse("1Mi"),
+			want:  resource.MustParse("64Mi"),
+		},
+		{
+			msg:   "64.1Mi rounded up to nearest 1Mi = 65Mi",
+			input: resource.MustParse("64.1Mi"),
+			unit:  resource.MustParse("1Mi"),
+			want:  resource.MustParse("65Mi"),
+		},
+		{
+			msg:   "990Mi rounded up to nearest 1Gi = 1Gi",
+			input: resource.MustParse("990Mi"),
+			unit:  resource.MustParse("1Gi"),
+			want:  resource.MustParse("1Gi"),
+		},
+	}
+
+	for _, test := range tests {
+		result := roundUp(test.input, test.unit)
+		assert.True(t, test.want.Equal(result), test.msg)
+	}
+}


### PR DESCRIPTION
Previously calculated limits are emitted with as much precision as necessary to express the result.
For example: memory request `101Mi` would result in a limit of `116496793600m` because 101Mi * 1.1 (defaultLimitRequestRatio) = 116496793.6 bytes.
We want it rounded up to `112Mi` instead.

This change outputs the calculated limit in a readable form rounded up:
- Use KiB precision as default
- Use MiB precision for values greater than 10MiB

Unfortunately we [cannot output](https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go#L73-L81) fractional digits, so I decided to pick 10MiB as the threshold to jump to next rounding precision.

Changes to `podtemplatespec_test.go` are clean up. Quantity can be represented internally as [int64Amount or infDecAmount](https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go#L102-L104). Previously I rounded the `result` and `want` values to get rid of the difference in representation and scale. I realize now [Equal](https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go#L623) can be used to make an apples to apples comparison. I'll have a follow up PR to clean up the rest of the test cases to use `Equal`.

### Testing
`minikube start` `make tunnel`
`skaffold dev`

Apply the following
```
apiVersion: v1
kind: Pod
metadata:
  name: test-pod
  namespace: devops
spec:
  containers:
  - name: nginx
    image: "nginx:1.14.2"
    ports:
    - containerPort: 80
    resources:
      requests:
        memory: "101Mi"
```
`kubectl describe pod test-pod` shows the calculated limit as `112Mi`.

Other tests for requests.memory and the resulting *1.1 limit
256Ki -> 282Ki
9Mi -> 10138Ki (this is below the 10Mi threshold, so it rounds *1.1 result to nearest Ki)
50Mi -> 55Mi
12Gi -> 13517Mi