### PR TITLE
Fix up unit tests to use Equal

### DIFF
--- a/pkg/mutators/podtemplatespec_test.go
+++ b/pkg/mutators/podtemplatespec_test.go
@@ -170,11 +170,7 @@ func TestValidateMemoryRatio(t *testing.T) {
 		}
 
 		err := testPts.validateMemoryRequirements(container, test.mc)
-		if test.wantError {
-			assert.Error(t, err, test.msg)
-		} else {
-			assert.NoError(t, err, test.msg)
-		}
+		assert.Equal(t, test.wantError, err != nil, test.msg)
 	}
 }
 

--- a/pkg/quantity/quantity.go
+++ b/pkg/quantity/quantity.go
@@ -77,10 +77,6 @@ func Max(x resource.Quantity, y resource.Quantity) resource.Quantity {
 	return xCopy
 }
 
-func Ptr(q resource.Quantity) *resource.Quantity {
-	return &q
-}
-
 // Rounds up input q to the nearest BinarySI representation Mi/Ki.
 func RoundUpBinarySI(q resource.Quantity) resource.Quantity {
 	qCopy := q.DeepCopy()

--- a/pkg/quantity/quantity_test.go
+++ b/pkg/quantity/quantity_test.go
@@ -329,7 +329,7 @@ func TestMin(t *testing.T) {
 		{
 			inputA: resource.MustParse("256Mi"),
 			inputB: resource.MustParse("256.123Mi"),
-			want:   *Ptr(resource.MustParse("256Mi")).ToDec(), // for large values it stores as Dec
+			want:   resource.MustParse("256Mi"),
 			msg:    "Min(256Mi, 256.123Mi) = 256Mi",
 		},
 		{
@@ -341,7 +341,8 @@ func TestMin(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.want, Min(test.inputA, test.inputB), test.msg)
+		result := Min(test.inputA, test.inputB)
+		assert.True(t, test.want.Equal(result), test.msg)
 	}
 }
 
@@ -357,19 +358,20 @@ func TestMax(t *testing.T) {
 		{
 			inputA: resource.MustParse("256Mi"),
 			inputB: resource.MustParse("256.123Mi"),
-			want:   *Ptr(resource.MustParse("256.123Mi")).ToDec(), // for large values it stores as Dec
+			want:   resource.MustParse("256.123Mi"),
 			msg:    "Max(256Mi, 256.123Mi) = 256.123Mi",
 		},
 		{
 			inputA: resource.MustParse("0.12345Gi"),
 			inputB: resource.MustParse("5Ki"),
-			want:   *Ptr(resource.MustParse("0.12345Gi")).ToDec(),
+			want:   resource.MustParse("0.12345Gi"),
 			msg:    "Max(0.12345Gi, 5Ki) = 0.12345Gi",
 		},
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.want, Max(test.inputA, test.inputB), test.msg)
+		result := Max(test.inputA, test.inputB)
+		assert.True(t, test.want.Equal(result), test.msg)
 	}
 }
 


### PR DESCRIPTION
Clean up unit tests.

Quantity can be represented internally as [int64Amount or infDecAmount](https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go#L102-L104). Previously I manually called [.ToDec()](https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go#L490) to get rid of the difference in representation. I realize now [Equal](https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go#L623) can be used to make an apples to apples comparison, so switching to that instead.

### Testing
`make test`

No-op for hedgetrimmer functionality. Only changes to unit tests.