### PR TITLE
Fix dry-run, add context log values

### DIFF
--- a/internal/admission/admission.go
+++ b/internal/admission/admission.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/kanopy-platform/hedgetrimmer/pkg/limitrange"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -91,6 +92,14 @@ func (r *Router) Handle(ctx context.Context, req admission.Request) admission.Re
 	if handler == nil {
 		return admission.Denied(fmt.Sprintf("no handlers for %s version %s", kind.Kind, kind.Version))
 	}
+
+	logr := log.FromContext(ctx,
+		"resource", req.Resource,
+		"namespace", req.Namespace,
+		"name", req.Name,
+		"operation", req.Operation,
+	)
+	ctx = log.IntoContext(ctx, logr)
 
 	cfg, err := r.limitRanger.LimitRangeConfig(req.Namespace)
 	if err != nil {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -135,6 +135,7 @@ func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {
 
 	ptm := mutators.NewPodTemplateSpec(
 		mutators.WithDefaultMemoryLimitRequestRatio(viper.GetFloat64("default-memory-limit-request-ratio")),
+		mutators.WithDryRun(viper.GetBool("dry-run")),
 	)
 
 	handlers, err := getHandlers(viper.GetStringSlice("resources"), ptm)

--- a/pkg/admission/handlers/cronjob.go
+++ b/pkg/admission/handlers/cronjob.go
@@ -43,7 +43,7 @@ func (c *CronjobHandler) Handle(ctx context.Context, req kadmission.Request) kad
 		return kadmission.Errored(http.StatusBadRequest, err)
 	}
 
-	pts, err := c.ptm.Mutate(out.Spec.JobTemplate.Spec.Template, lrConfig)
+	pts, err := c.ptm.Mutate(ctx, out.Spec.JobTemplate.Spec.Template, lrConfig)
 	if err != nil {
 		reason := fmt.Sprintf("failed to mutate cronjob %s/%s: %s", out.Namespace, out.Name, err)
 		log.Error(err, reason)

--- a/pkg/admission/handlers/daemonset.go
+++ b/pkg/admission/handlers/daemonset.go
@@ -43,7 +43,7 @@ func (d *DaemonSetHandler) Handle(ctx context.Context, req kadmission.Request) k
 		return kadmission.Errored(http.StatusBadRequest, err)
 	}
 
-	pts, err := d.ptm.Mutate(out.Spec.Template, lrConfig)
+	pts, err := d.ptm.Mutate(ctx, out.Spec.Template, lrConfig)
 	if err != nil {
 		reason := fmt.Sprintf("failed to mutate DaemonSet %s/%s: %s", out.Namespace, out.Name, err)
 		log.Error(err, reason)

--- a/pkg/admission/handlers/deployment.go
+++ b/pkg/admission/handlers/deployment.go
@@ -40,7 +40,7 @@ func (d *DeploymentHandler) Handle(ctx context.Context, req kadmission.Request) 
 		return kadmission.Errored(http.StatusBadRequest, err)
 	}
 
-	pts, err := d.ptm.Mutate(out.Spec.Template, lrConfig)
+	pts, err := d.ptm.Mutate(ctx, out.Spec.Template, lrConfig)
 	if err != nil {
 		reason := fmt.Sprintf("failed to mutate deployment %s/%s: %s", out.Namespace, out.Name, err)
 		log.Error(err, reason)

--- a/pkg/admission/handlers/job.go
+++ b/pkg/admission/handlers/job.go
@@ -43,7 +43,7 @@ func (j *JobHandler) Handle(ctx context.Context, req kadmission.Request) kadmiss
 		return kadmission.Errored(http.StatusBadRequest, err)
 	}
 
-	pts, err := j.ptm.Mutate(out.Spec.Template, lrConfig)
+	pts, err := j.ptm.Mutate(ctx, out.Spec.Template, lrConfig)
 	if err != nil {
 		reason := fmt.Sprintf("failed to mutate job %s/%s: %s", out.Namespace, out.Name, err)
 		log.Error(err, reason)

--- a/pkg/admission/handlers/pod.go
+++ b/pkg/admission/handlers/pod.go
@@ -53,7 +53,7 @@ func (p *PodHandler) Handle(ctx context.Context, req kadmission.Request) kadmiss
 		Spec: out.Spec,
 	}
 
-	pts, err := p.ptm.Mutate(mout, lrConfig)
+	pts, err := p.ptm.Mutate(ctx, mout, lrConfig)
 	if err != nil {
 		reason := fmt.Sprintf("failed to mutate pod %s/%s: %s", out.Namespace, out.Name, err)
 		log.Error(err, reason)

--- a/pkg/admission/handlers/replicaset.go
+++ b/pkg/admission/handlers/replicaset.go
@@ -43,7 +43,7 @@ func (r *ReplicaSetHandler) Handle(ctx context.Context, req kadmission.Request) 
 		return kadmission.Errored(http.StatusBadRequest, err)
 	}
 
-	pts, err := r.ptm.Mutate(out.Spec.Template, lrConfig)
+	pts, err := r.ptm.Mutate(ctx, out.Spec.Template, lrConfig)
 	if err != nil {
 		reason := fmt.Sprintf("failed to mutate ReplicaSet %s/%s: %s", out.Namespace, out.Name, err)
 		log.Error(err, reason)

--- a/pkg/admission/handlers/replicationcontroller.go
+++ b/pkg/admission/handlers/replicationcontroller.go
@@ -43,7 +43,7 @@ func (r *ReplicationControllerHandler) Handle(ctx context.Context, req kadmissio
 		return kadmission.Errored(http.StatusBadRequest, err)
 	}
 
-	pts, err := r.ptm.Mutate(*out.Spec.Template, lrConfig)
+	pts, err := r.ptm.Mutate(ctx, *out.Spec.Template, lrConfig)
 	if err != nil {
 		reason := fmt.Sprintf("failed to mutate ReplicationController %s/%s: %s", out.Namespace, out.Name, err)
 		log.Error(err, reason)

--- a/pkg/admission/handlers/sts.go
+++ b/pkg/admission/handlers/sts.go
@@ -41,7 +41,7 @@ func (sts *StatefulSetHandler) Handle(ctx context.Context, req kadmission.Reques
 		return kadmission.Errored(http.StatusBadRequest, err)
 	}
 
-	pts, err := sts.ptm.Mutate(out.Spec.Template, lrConfig)
+	pts, err := sts.ptm.Mutate(ctx, out.Spec.Template, lrConfig)
 	if err != nil {
 		reason := fmt.Sprintf("failed to mutate statefulset %s/%s: %s", out.Namespace, out.Name, err)
 		log.Error(err, reason)

--- a/pkg/admission/handlers/util_test.go
+++ b/pkg/admission/handlers/util_test.go
@@ -28,7 +28,7 @@ func (mm *MockMutator) SetErr(err error) {
 	mm.err = err
 }
 
-func (mm *MockMutator) Mutate(inputs corev1.PodTemplateSpec, config *limitrange.Config) (corev1.PodTemplateSpec, error) {
+func (mm *MockMutator) Mutate(ctx context.Context, inputs corev1.PodTemplateSpec, config *limitrange.Config) (corev1.PodTemplateSpec, error) {
 	return mm.spec, mm.err
 }
 

--- a/pkg/admission/mutator.go
+++ b/pkg/admission/mutator.go
@@ -1,10 +1,12 @@
 package admission
 
 import (
+	"context"
+
 	"github.com/kanopy-platform/hedgetrimmer/pkg/limitrange"
 	corev1 "k8s.io/api/core/v1"
 )
 
 type PodTemplateSpecMutator interface {
-	Mutate(inputPts corev1.PodTemplateSpec, limitRangeMemory *limitrange.Config) (corev1.PodTemplateSpec, error)
+	Mutate(ctx context.Context, inputPts corev1.PodTemplateSpec, limitRangeMemory *limitrange.Config) (corev1.PodTemplateSpec, error)
 }

--- a/pkg/mutators/options.go
+++ b/pkg/mutators/options.go
@@ -13,3 +13,9 @@ func WithDefaultMemoryLimitRequestRatio(ratio float64) OptionsFunc {
 		pts.defaultMemoryLimitRequestRatio = resource.MustParse(fmt.Sprintf("%v", ratio))
 	}
 }
+
+func WithDryRun(dryRun bool) OptionsFunc {
+	return func(pts *PodTemplateSpec) {
+		pts.dryRun = dryRun
+	}
+}

--- a/pkg/mutators/podtemplatespec.go
+++ b/pkg/mutators/podtemplatespec.go
@@ -51,7 +51,7 @@ func (p *PodTemplateSpec) setAndValidateResourceRequirements(ctx context.Context
 	for idx := range containers {
 		container := &containers[idx]
 		if p.dryRun {
-			// On dry-run use a copy to go through the motions, do not modify actual
+			// On dry-run use a copy to go through the motions, do not modify original
 			container = container.DeepCopy()
 		}
 

--- a/pkg/mutators/podtemplatespec_test.go
+++ b/pkg/mutators/podtemplatespec_test.go
@@ -1,7 +1,7 @@
 package mutators
 
 import (
-	"os"
+	"context"
 	"testing"
 
 	"github.com/kanopy-platform/hedgetrimmer/pkg/limitrange"
@@ -10,15 +10,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-var testPts *PodTemplateSpec
-
-func TestMain(m *testing.M) {
-	testPts = NewPodTemplateSpec(WithDefaultMemoryLimitRequestRatio(1.1))
-	os.Exit(m.Run())
-}
-
 func TestMutate(t *testing.T) {
 	t.Parallel()
+
+	pts := NewPodTemplateSpec(WithDefaultMemoryLimitRequestRatio(1.1))
 
 	limitRangeMemory := &limitrange.Config{
 		HasDefaultRequest:       true,
@@ -85,7 +80,7 @@ func TestMutate(t *testing.T) {
 		for idx := range inputs {
 			input := inputs[idx]
 
-			result, err := testPts.Mutate(input, test.config)
+			result, err := pts.Mutate(context.Background(), input, test.config)
 			if test.wantError {
 				assert.Error(t, err, test.msg)
 			} else {
@@ -104,6 +99,8 @@ func TestMutate(t *testing.T) {
 
 func TestValidateMemoryRatio(t *testing.T) {
 	t.Parallel()
+
+	pts := NewPodTemplateSpec(WithDefaultMemoryLimitRequestRatio(1.1))
 
 	memoryConfig := &limitrange.Config{
 		HasMaxLimitRequestRatio: true,
@@ -169,13 +166,37 @@ func TestValidateMemoryRatio(t *testing.T) {
 			},
 		}
 
-		err := testPts.validateMemoryRequirements(container, test.mc)
+		err := pts.validateMemoryRequirements(context.Background(), container, test.mc)
 		assert.Equal(t, test.wantError, err != nil, test.msg)
 	}
 }
 
+func TestValidateMemoryRatioDryRun(t *testing.T) {
+	t.Parallel()
+
+	pts := NewPodTemplateSpec(WithDryRun(true))
+
+	// Container Limit/Request ratio exceeds LimitRange Config but no error on dry-run
+	limitrangeConfig := &limitrange.Config{
+		HasMaxLimitRequestRatio: true,
+		MaxLimitRequestRatio:    resource.MustParse("1.25"),
+	}
+
+	container := corev1.Container{
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")},
+			Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("3Gi")},
+		},
+	}
+
+	err := pts.validateMemoryRequirements(context.Background(), container, limitrangeConfig)
+	assert.NoError(t, err, "Do not error on validation failure for dry-run")
+}
+
 func TestSetMemoryRequest(t *testing.T) {
 	t.Parallel()
+
+	pts := NewPodTemplateSpec(WithDefaultMemoryLimitRequestRatio(1.1))
 
 	memoryConfig := &limitrange.Config{
 		HasDefaultRequest: true,
@@ -246,13 +267,41 @@ func TestSetMemoryRequest(t *testing.T) {
 			},
 		}
 
-		testPts.setMemoryRequest(container, test.mc)
+		pts.setMemoryRequest(context.Background(), container, test.mc)
 		assert.Equal(t, wantContainer, container, test.msg)
 	}
 }
 
+func TestSetMemoryRequestDryRun(t *testing.T) {
+	t.Parallel()
+
+	pts := NewPodTemplateSpec(WithDryRun(true))
+
+	// LimitRange config defaults are not applied on dry-run
+	limitrangeConfig := &limitrange.Config{
+		HasDefaultRequest: true,
+		HasDefaultLimit:   true,
+		DefaultRequest:    resource.MustParse("5Gi"),
+		DefaultLimit:      resource.MustParse("6Gi"),
+	}
+
+	container := corev1.Container{
+		Resources: corev1.ResourceRequirements{
+			Requests: nil,
+			Limits:   nil,
+		},
+	}
+
+	containerCopy := *container.DeepCopy()
+
+	pts.setMemoryRequest(context.Background(), &container, limitrangeConfig)
+	assert.Equal(t, containerCopy, container, "Do not mutate for dry-run")
+}
+
 func TestSetMemoryLimit(t *testing.T) {
 	t.Parallel()
+
+	pts := NewPodTemplateSpec(WithDefaultMemoryLimitRequestRatio(1.1))
 
 	memoryConfigWithoutMaxRatio := &limitrange.Config{
 		HasDefaultLimit:         true,
@@ -338,9 +387,33 @@ func TestSetMemoryLimit(t *testing.T) {
 			},
 		}
 
-		testPts.setMemoryLimit(&container, test.mc)
+		pts.setMemoryLimit(context.Background(), &container, test.mc)
 
 		assert.True(t, test.requests.Memory().Equal(*container.Resources.Requests.Memory()), test.msg)
 		assert.True(t, test.wantLimits.Memory().Equal(*container.Resources.Limits.Memory()), test.msg)
 	}
+}
+
+func TestSetMemoryLimitDryRun(t *testing.T) {
+	t.Parallel()
+
+	pts := NewPodTemplateSpec(WithDryRun(true))
+
+	// LimitRange config defaults are not applied on dry-run
+	limitrangeConfig := &limitrange.Config{
+		HasDefaultLimit: true,
+		DefaultLimit:    resource.MustParse("50Mi"),
+	}
+
+	container := corev1.Container{
+		Resources: corev1.ResourceRequirements{
+			Requests: nil,
+			Limits:   nil,
+		},
+	}
+
+	containerCopy := *container.DeepCopy()
+
+	pts.setMemoryLimit(context.Background(), &container, limitrangeConfig)
+	assert.Equal(t, containerCopy, container, "Do not mutate for dry-run")
 }


### PR DESCRIPTION
Currently specifying `--dry-run` still results in setting requests/limits. This fixes dry-run mode so that Mutate() prints out to log instead. Adding context parameter to Mutate() so that it can retrieve the logger.

The rest of the change is to provide more info in logs.
Currently in each `Handle` method, the logger is retrieved via context argument. The change in `admission.go` adds key-value pairs so that all logs will contain this information: `resource`, `namespace`, `name`, `operation`.
Example log:
`[hedgetrimmer] {"level":"info","ts":1666893996.5524142,"msg":"[dry-run] memory request (10Gi) and limit (0) must be set","resource":{"group":"","version":"v1","resource":"pods"},"namespace":"devops","name":"test-pod","operation":"CREATE"}`

### Testing
`minikube start` `make tunnel`
In [examples/k8s/deployment.yaml](https://github.com/kanopy-platform/hedgetrimmer/blob/main/examples/k8s/deployment.yaml#L42) args add `- "--dry-run"`.
`skaffold dev`

Apply the following:
```
apiVersion: v1
kind: Pod
metadata:
  name: test-pod
  namespace: devops
spec:
  containers:
  - name: nginx
    image: "nginx:1.14.2"
    ports:
    - containerPort: 80
    resources:
      requests:
        memory: "10Gi"
```

`kubectl describe pod test-pod`, notice that Limits.memory is not set.
hedgetrimmer logs shows `[dry-run]` logs.
Note that if instead you want to test when `limits.memory` is set in the Pod Spec and request is unset, kubernetes [automatically](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits) copies the limits to the requests, so hedgetrimmer is not at play there.

Repeated with `--dry-run` arg removed and can see pod requests/limits are mutated as normal.