### PR TITLE
Bugfix: metrics listen port

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -67,7 +67,7 @@ steps:
       secret_key:
         from_secret: ecr_secret_key
     when:
-      event: [push, pull_request]
+      event: [push]
 
   - name: publish-tag
     image: plugins/kaniko-ecr

--- a/.drone.yml
+++ b/.drone.yml
@@ -93,4 +93,4 @@ steps:
       secret_key:
         from_secret: ecr_secret_key
     when:
-      event: [tag]
+      event: [tag, pull_request]

--- a/.drone.yml
+++ b/.drone.yml
@@ -67,7 +67,7 @@ steps:
       secret_key:
         from_secret: ecr_secret_key
     when:
-      event: [push]
+      event: [push, pull_request]
 
   - name: publish-tag
     image: plugins/kaniko-ecr
@@ -93,4 +93,4 @@ steps:
       secret_key:
         from_secret: ecr_secret_key
     when:
-      event: [tag, pull_request]
+      event: [tag]

--- a/examples/k8s/deployment.yaml
+++ b/examples/k8s/deployment.yaml
@@ -79,7 +79,7 @@ metadata:
     app: hedgetrimmer
 spec:
   ports:
-  - port: 8081
+  - port: 80
     targetPort: 8081
     name: metrics   
   - port: 8443

--- a/examples/k8s/deployment.yaml
+++ b/examples/k8s/deployment.yaml
@@ -58,7 +58,7 @@ spec:
             initialDelaySeconds: 3
             periodSeconds: 5
           ports:
-            - containerPort: 80
+            - containerPort: 8081
               name: metrics
             - containerPort: 8443
               name: webhooks
@@ -79,8 +79,8 @@ metadata:
     app: hedgetrimmer
 spec:
   ports:
-  - port: 80
-    targetPort: 80
+  - port: 8081
+    targetPort: 8081
     name: metrics   
   - port: 8443
     targetPort: 8443

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -49,6 +49,7 @@ func NewRootCommand() *cobra.Command {
 
 	cmd.PersistentFlags().String("log-level", "info", "Configure log level")
 	cmd.PersistentFlags().Int("webhook-listen-port", 8443, "Admission webhook listen port")
+	cmd.PersistentFlags().Int("metrics-listen-port", 8081, "Metrics listen port")
 	cmd.PersistentFlags().String("webhook-certs-dir", "/etc/webhook/certs", "Admission webhook TLS certificate directory")
 	cmd.PersistentFlags().Bool("dry-run", false, "Controller dry-run changes only")
 	cmd.PersistentFlags().Float64("default-memory-limit-request-ratio", 1.1, "Default memory limit/request ratio")
@@ -101,7 +102,7 @@ func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {
 		Host:                   "0.0.0.0",
 		Port:                   viper.GetInt("webhook-listen-port"),
 		CertDir:                viper.GetString("webhook-certs-dir"),
-		MetricsBindAddress:     "0.0.0.0:80",
+		MetricsBindAddress:     fmt.Sprintf("0.0.0.0:%d", viper.GetInt("metrics-listen-port")),
 		HealthProbeBindAddress: ":8080",
 		LeaderElection:         true,
 		LeaderElectionID:       "hedgetrimmer",


### PR DESCRIPTION
Not allowed to bind on privileged port `80`

Error when deploy to test:
```
{"level":"info","ts":1667856056.965965,"logger":"controller-runtime.metrics","msg":"Metrics server is starting to listen","addr":"0.0.0.0:80"}

{"level":"error","ts":1667856056.9661546,"logger":"controller-runtime.metrics","msg":"metrics server failed to listen. You may want to disable the metrics server or use another port if it is due to conflicts","error":"error listening on 0.0.0.0:80: listen tcp 0.0.0.0:80: bind: permission denied","stacktrace":...}
```

### Testing
Still works on minikube.
Will release and test on test cluster.