### PR TITLE
Bugfix Limit calc RoundDown

### DIFF
--- a/examples/k8s/deployment.yaml
+++ b/examples/k8s/deployment.yaml
@@ -120,6 +120,12 @@ webhooks:
   failurePolicy: Ignore
   name: v1beta1.hedgetrimmer.kanopy-platform.github.io
   reinvocationPolicy: IfNeeded
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
   rules:
   - apiGroups:
     - apps

--- a/pkg/mutators/podtemplatespec_test.go
+++ b/pkg/mutators/podtemplatespec_test.go
@@ -35,7 +35,6 @@ func TestMutate(t *testing.T) {
 				HasMaxLimitRequestRatio: false,
 				DefaultRequest:          resource.MustParse("50Mi"),
 				DefaultLimit:            resource.MustParse("64Mi"),
-				MaxLimitRequestRatio:    resource.MustParse("1.1"),
 			},
 			want: []corev1.Container{
 				{

--- a/pkg/mutators/podtemplatespec_test.go
+++ b/pkg/mutators/podtemplatespec_test.go
@@ -15,14 +15,6 @@ func TestMutate(t *testing.T) {
 
 	pts := NewPodTemplateSpec(WithDefaultMemoryLimitRequestRatio(1.1))
 
-	limitRangeMemory := &limitrange.Config{
-		HasDefaultRequest:       true,
-		HasDefaultLimit:         true,
-		HasMaxLimitRequestRatio: false,
-		DefaultRequest:          resource.MustParse("50Mi"),
-		DefaultLimit:            resource.MustParse("64Mi"),
-	}
-
 	tests := []struct {
 		msg        string
 		containers []corev1.Container
@@ -37,7 +29,14 @@ func TestMutate(t *testing.T) {
 					Resources: corev1.ResourceRequirements{},
 				},
 			},
-			config: limitRangeMemory,
+			config: &limitrange.Config{
+				HasDefaultRequest:       true,
+				HasDefaultLimit:         true,
+				HasMaxLimitRequestRatio: false,
+				DefaultRequest:          resource.MustParse("50Mi"),
+				DefaultLimit:            resource.MustParse("64Mi"),
+				MaxLimitRequestRatio:    resource.MustParse("1.1"),
+			},
 			want: []corev1.Container{
 				{
 					Resources: corev1.ResourceRequirements{
@@ -57,7 +56,14 @@ func TestMutate(t *testing.T) {
 					},
 				},
 			},
-			config: limitRangeMemory,
+			config: &limitrange.Config{
+				HasDefaultRequest:       true,
+				HasDefaultLimit:         true,
+				HasMaxLimitRequestRatio: true,
+				DefaultRequest:          resource.MustParse("50Mi"),
+				DefaultLimit:            resource.MustParse("64Mi"),
+				MaxLimitRequestRatio:    resource.MustParse("1.1"),
+			},
 			want: []corev1.Container{
 				{
 					Resources: corev1.ResourceRequirements{
@@ -391,14 +397,14 @@ func TestSetMemoryLimit(t *testing.T) {
 			requests:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("49Mi")},
 			limits:     corev1.ResourceList{},
 			mc:         memoryConfigWithoutMaxRatio,
-			wantLimits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("54Mi")},
+			wantLimits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("53Mi")},
 		},
 		{
 			msg:        "MaxLimitRequestMemoryRatio set, defaultMemoryLimit and defaultLimitRequestMemoryRatio both larger, use MaxLimitRequestMemoryRatio",
 			requests:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("45Mi")},
 			limits:     corev1.ResourceList{},
 			mc:         memoryConfigWithMaxRatio,
-			wantLimits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("48Mi")},
+			wantLimits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("47Mi")},
 		},
 		{
 			msg:      "MaxLimitRequestMemoryRatio set, defaultMemoryLimit and defaultLimitRequestMemoryRatio both smaller, use MaxLimitRequestMemoryRatio",

--- a/pkg/mutators/podtemplatespec_test.go
+++ b/pkg/mutators/podtemplatespec_test.go
@@ -52,7 +52,7 @@ func TestMutate(t *testing.T) {
 			containers: []corev1.Container{
 				{
 					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("5Gi")},
+						Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("5.1Gi")},
 					},
 				},
 			},
@@ -67,8 +67,8 @@ func TestMutate(t *testing.T) {
 			want: []corev1.Container{
 				{
 					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("5Gi")},
-						Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("5632Mi")},
+						Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("5.1Gi")},
+						Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("5744Mi")},
 					},
 				},
 			},

--- a/pkg/quantity/quantity.go
+++ b/pkg/quantity/quantity.go
@@ -36,23 +36,23 @@ func MulFloat64(x resource.Quantity, y float64) (resource.Quantity, error) {
 	return Mul(x, yQuantity), nil
 }
 
-// Returns x/y rounded to the specified scale s.
+// Returns x/y rounded to the specified scale.
 // Note that inf.Scale is inverted. -2 means 100, 2 means 0.01.
-func Div(x resource.Quantity, y resource.Quantity, s inf.Scale, rounder inf.Rounder) resource.Quantity {
+func Div(x resource.Quantity, y resource.Quantity, scale inf.Scale, rounder inf.Rounder) resource.Quantity {
 	result := resource.Quantity{}
 	result.Format = x.Format
 
-	result.AsDec().QuoRound(x.AsDec(), y.AsDec(), s, rounder)
+	result.AsDec().QuoRound(x.AsDec(), y.AsDec(), scale, rounder)
 	return result
 }
 
-func DivFloat64(x resource.Quantity, y float64, s inf.Scale, rounder inf.Rounder) (resource.Quantity, error) {
+func DivFloat64(x resource.Quantity, y float64, scale inf.Scale, rounder inf.Rounder) (resource.Quantity, error) {
 	yQuantity, err := resource.ParseQuantity(fmt.Sprintf("%v", y))
 	if err != nil {
 		return x, err
 	}
 
-	return Div(x, yQuantity, s, rounder), nil
+	return Div(x, yQuantity, scale, rounder), nil
 }
 
 func Min(x resource.Quantity, y resource.Quantity) resource.Quantity {

--- a/pkg/quantity/quantity.go
+++ b/pkg/quantity/quantity.go
@@ -36,23 +36,23 @@ func MulFloat64(x resource.Quantity, y float64) (resource.Quantity, error) {
 	return Mul(x, yQuantity), nil
 }
 
-// Returns x/y rounded up to the specified scale s.
+// Returns x/y rounded to the specified scale s.
 // Note that inf.Scale is inverted. -2 means 100, 2 means 0.01.
-func Div(x resource.Quantity, y resource.Quantity, s inf.Scale) resource.Quantity {
+func Div(x resource.Quantity, y resource.Quantity, s inf.Scale, rounder inf.Rounder) resource.Quantity {
 	result := resource.Quantity{}
 	result.Format = x.Format
 
-	result.AsDec().QuoRound(x.AsDec(), y.AsDec(), s, inf.RoundUp)
+	result.AsDec().QuoRound(x.AsDec(), y.AsDec(), s, rounder)
 	return result
 }
 
-func DivFloat64(x resource.Quantity, y float64, s inf.Scale) (resource.Quantity, error) {
+func DivFloat64(x resource.Quantity, y float64, s inf.Scale, rounder inf.Rounder) (resource.Quantity, error) {
 	yQuantity, err := resource.ParseQuantity(fmt.Sprintf("%v", y))
 	if err != nil {
 		return x, err
 	}
 
-	return Div(x, yQuantity, s), nil
+	return Div(x, yQuantity, s, rounder), nil
 }
 
 func Min(x resource.Quantity, y resource.Quantity) resource.Quantity {
@@ -77,15 +77,15 @@ func Max(x resource.Quantity, y resource.Quantity) resource.Quantity {
 	return xCopy
 }
 
-// Rounds up input q to the nearest BinarySI representation Mi/Ki.
-func RoundUpBinarySI(q resource.Quantity) resource.Quantity {
+// Rounds input q to the nearest BinarySI representation Mi/Ki.
+func RoundBinarySI(q resource.Quantity, rounder inf.Rounder) resource.Quantity {
 	qCopy := q.DeepCopy()
 
 	// Note the implementation cannot use resource.RoundUp(), it operates using DecimalSI.
 	if qCopy.Cmp(TenMi) == 1 {
-		qCopy = roundUp(qCopy, OneMi)
+		qCopy = round(qCopy, OneMi, rounder)
 	} else {
-		qCopy = roundUp(qCopy, OneKi)
+		qCopy = round(qCopy, OneKi, rounder)
 	}
 
 	qCopy.Format = resource.BinarySI
@@ -93,6 +93,6 @@ func RoundUpBinarySI(q resource.Quantity) resource.Quantity {
 }
 
 // Performs integer division to round up q to the given unit.
-func roundUp(q resource.Quantity, unit resource.Quantity) resource.Quantity {
-	return Mul(Div(q, unit, 0), unit)
+func round(q resource.Quantity, unit resource.Quantity, rounder inf.Rounder) resource.Quantity {
+	return Mul(Div(q, unit, 0, rounder), unit)
 }

--- a/pkg/quantity/quantity_test.go
+++ b/pkg/quantity/quantity_test.go
@@ -221,47 +221,46 @@ func TestDiv(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		inputA resource.Quantity
-		inputB resource.Quantity
-		scale  inf.Scale
-		// roundingPrecision is the decimal place to compare want vs result due to loss of precision
-		roundingPrecision int32
-		want              resource.Quantity
-		msg               string
+		inputA          resource.Quantity
+		inputB          resource.Quantity
+		scale           inf.Scale
+		wantRoundedUp   resource.Quantity
+		wantRoundedDown resource.Quantity
+		msg             string
 	}{
 		{
-			inputA:            resource.MustParse("31.123456Gi"),
-			inputB:            resource.MustParse("8.123456789"),
-			scale:             6,
-			want:              *resource.NewDecimalQuantity(*inf.NewDec(4113834452825049, 6), resource.BinarySI),
-			roundingPrecision: -6,
-			msg:               "Div(parsed BinarySI, parsed DecimalSI)",
+			inputA:          resource.MustParse("31.123456Gi"),
+			inputB:          resource.MustParse("8.123456789"),
+			scale:           6, // 10^-6 precision
+			wantRoundedUp:   *resource.NewDecimalQuantity(*inf.NewDec(4113834452825049, 6), resource.BinarySI),
+			wantRoundedDown: *resource.NewDecimalQuantity(*inf.NewDec(4113834452825048, 6), resource.BinarySI),
+			msg:             "Div(parsed BinarySI, parsed DecimalSI)",
 		},
 		{
 			// 12345600 / -0.003456 = -3572222222...
-			inputA:            *resource.NewDecimalQuantity(*inf.NewDec(123456, -2), resource.DecimalSI),
-			inputB:            *resource.NewDecimalQuantity(*inf.NewDec(-3456, 6), resource.DecimalSI),
-			scale:             8,
-			want:              *resource.NewDecimalQuantity(*inf.NewDec(-357222222222222223, 8), resource.DecimalSI),
-			roundingPrecision: -8,
-			msg:               "Div(DecimalSI, negative DecimalSI with decimal digits)",
+			inputA:          *resource.NewDecimalQuantity(*inf.NewDec(123456, -2), resource.DecimalSI),
+			inputB:          *resource.NewDecimalQuantity(*inf.NewDec(-3456, 6), resource.DecimalSI),
+			scale:           8, // 10^-8 precision
+			wantRoundedUp:   *resource.NewDecimalQuantity(*inf.NewDec(-357222222222222223, 8), resource.DecimalSI),
+			wantRoundedDown: *resource.NewDecimalQuantity(*inf.NewDec(-357222222222222222, 8), resource.DecimalSI),
+			msg:             "Div(DecimalSI, negative DecimalSI with decimal digits)",
 		},
 		{
-			inputA:            resource.MustParse("518Ti"),
-			inputB:            resource.MustParse("0.123456789"),
-			scale:             3,
-			want:              *resource.NewDecimalQuantity(*inf.NewDec(4613330929803852262, 3), resource.BinarySI),
-			roundingPrecision: -3,
-			msg:               "Div(overflow testing)",
+			inputA:          resource.MustParse("518Ti"),
+			inputB:          resource.MustParse("0.123456789"),
+			scale:           3, // 10^-3 precision
+			wantRoundedUp:   *resource.NewDecimalQuantity(*inf.NewDec(4613330929803852262, 3), resource.BinarySI),
+			wantRoundedDown: *resource.NewDecimalQuantity(*inf.NewDec(4613330929803852261, 3), resource.BinarySI),
+			msg:             "Div(overflow testing)",
 		},
 	}
 
 	for _, test := range tests {
-		result := Div(test.inputA, test.inputB, test.scale)
-		result.RoundUp(resource.Scale(test.roundingPrecision))
-		test.want.RoundUp(resource.Scale(test.roundingPrecision))
+		result := Div(test.inputA, test.inputB, test.scale, inf.RoundUp)
+		assert.Equal(t, test.wantRoundedUp, result, test.msg+", RoundUp")
 
-		assert.Equal(t, test.want, result, test.msg)
+		result = Div(test.inputA, test.inputB, test.scale, inf.RoundDown)
+		assert.Equal(t, test.wantRoundedDown, result, test.msg+", RoundDown")
 	}
 }
 
@@ -269,50 +268,53 @@ func TestDivFloat64(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		inputA resource.Quantity
-		inputB float64
-		scale  inf.Scale
-		want   resource.Quantity
-		// roundingPrecision is the decimal place to compare want vs result due to loss of precision
-		roundingPrecision int32
-		wantError         bool
-		msg               string
+		inputA        resource.Quantity
+		inputB        float64
+		scale         inf.Scale
+		wantRoundUp   resource.Quantity
+		wantRoundDown resource.Quantity
+		wantError     bool
+		msg           string
 	}{
 		{
-			inputA:            resource.MustParse("256Mi"),
-			inputB:            -1 / 6.0,
-			scale:             0,
-			want:              *resource.NewDecimalQuantity(*inf.NewDec(-1610612736, 0), resource.BinarySI),
-			roundingPrecision: 1, // precision to 10s
-			msg:               "DivFloat64(parsed BinarySI, negative repeating decimal)",
+			inputA:        resource.MustParse("256Mi"),
+			inputB:        -1 / 6.0,
+			scale:         -1, // 10^1 precision
+			wantRoundUp:   *resource.NewDecimalQuantity(*inf.NewDec(-161061274, -1), resource.BinarySI),
+			wantRoundDown: *resource.NewDecimalQuantity(*inf.NewDec(-161061273, -1), resource.BinarySI),
+			msg:           "DivFloat64(parsed BinarySI, negative repeating decimal)",
 		},
 		{
-			inputA:            resource.MustParse("31Gi"),
-			inputB:            2.525873,
-			scale:             6,
-			want:              *resource.NewDecimalQuantity(*inf.NewDec(13178016687299797, 6), resource.BinarySI),
-			roundingPrecision: -6,
-			msg:               "DivFloat64(parsed BinarySI, positive float)",
+			inputA:        resource.MustParse("31Gi"),
+			inputB:        2.525873,
+			scale:         6, // 10^-6 precision
+			wantRoundUp:   *resource.NewDecimalQuantity(*inf.NewDec(13178016687299797, 6), resource.BinarySI),
+			wantRoundDown: *resource.NewDecimalQuantity(*inf.NewDec(13178016687299796, 6), resource.BinarySI),
+			msg:           "DivFloat64(parsed BinarySI, positive float)",
 		},
 		{
-			inputA:            resource.MustParse("5128Ti"),
-			inputB:            10.0 / 3333.0,
-			scale:             6,
-			want:              *resource.NewDecimalQuantity(*inf.NewDec(1879243932557534823, 0), resource.BinarySI),
-			roundingPrecision: 12, // precision to 10^12
-			msg:               "DivFloat64(overflow testing)",
+			inputA:        resource.MustParse("5128Ti"),
+			inputB:        10.0 / 3333.0,
+			scale:         -12, // 10^12 precision
+			wantRoundUp:   *resource.NewDecimalQuantity(*inf.NewDec(1879244, -12), resource.BinarySI),
+			wantRoundDown: *resource.NewDecimalQuantity(*inf.NewDec(1879243, -12), resource.BinarySI),
+			msg:           "DivFloat64(overflow testing)",
 		},
 	}
 
 	for _, test := range tests {
-		result, err := DivFloat64(test.inputA, test.inputB, test.scale)
+		result, err := DivFloat64(test.inputA, test.inputB, test.scale, inf.RoundUp)
 		if test.wantError {
 			assert.Error(t, err)
 		} else {
-			result.RoundUp(resource.Scale(test.roundingPrecision))
-			test.want.RoundUp(resource.Scale(test.roundingPrecision))
+			assert.Equal(t, test.wantRoundUp, result, test.msg+", RoundUp")
+		}
 
-			assert.Equal(t, test.want, result, test.msg)
+		result, err = DivFloat64(test.inputA, test.inputB, test.scale, inf.RoundDown)
+		if test.wantError {
+			assert.Error(t, err)
+		} else {
+			assert.Equal(t, test.wantRoundDown, result, test.msg+", RoundDown")
 		}
 	}
 }
@@ -375,79 +377,95 @@ func TestMax(t *testing.T) {
 	}
 }
 
-func TestRoundUpBinarySI(t *testing.T) {
+func TestRoundBinarySI(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		msg   string
-		input resource.Quantity
-		want  resource.Quantity
+		msg             string
+		input           resource.Quantity
+		wantRoundedUp   resource.Quantity
+		wantRoundedDown resource.Quantity
 	}{
 		{
-			msg:   "123.4Ki rounds up to 124Ki",
-			input: resource.MustParse("123.4Ki"),
-			want:  resource.MustParse("124Ki"),
+			msg:             "123.4Ki rounded",
+			input:           resource.MustParse("123.4Ki"),
+			wantRoundedUp:   resource.MustParse("124Ki"),
+			wantRoundedDown: resource.MustParse("123Ki"),
 		},
 		{
-			msg:   "9.8Mi rounds up to 10036Ki",
-			input: resource.MustParse("9.8Mi"),
-			want:  resource.MustParse("10036Ki"),
+			msg:             "9.8Mi rounded",
+			input:           resource.MustParse("9.8Mi"),
+			wantRoundedUp:   resource.MustParse("10036Ki"),
+			wantRoundedDown: resource.MustParse("10035Ki"),
 		},
 		{
-			msg:   "10.1Mi rounds up to 11Mi",
-			input: resource.MustParse("10.1Mi"),
-			want:  resource.MustParse("11Mi"),
+			msg:             "10.5Mi rounded",
+			input:           resource.MustParse("10.5Mi"),
+			wantRoundedUp:   resource.MustParse("11Mi"),
+			wantRoundedDown: resource.MustParse("10Mi"),
 		},
 		{
-			msg:   "15Gi no rounding",
-			input: resource.MustParse("15Gi"),
-			want:  resource.MustParse("15Gi"),
+			msg:             "15Gi no rounding",
+			input:           resource.MustParse("15Gi"),
+			wantRoundedUp:   resource.MustParse("15Gi"),
+			wantRoundedDown: resource.MustParse("15Gi"),
 		},
 	}
 
 	for _, test := range tests {
-		result := RoundUpBinarySI(test.input)
-		assert.True(t, test.want.Equal(result), test.msg)
+		result := RoundBinarySI(test.input, inf.RoundUp)
+		assert.True(t, test.wantRoundedUp.Equal(result), test.msg+", RoundUp")
+
+		result = RoundBinarySI(test.input, inf.RoundDown)
+		assert.True(t, test.wantRoundedDown.Equal(result), test.msg+", RoundDown")
 	}
 }
 
-func TestRoundUp(t *testing.T) {
+func TestRound(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		msg   string
-		input resource.Quantity
-		unit  resource.Quantity
-		want  resource.Quantity
+		msg             string
+		input           resource.Quantity
+		unit            resource.Quantity
+		wantRoundedUp   resource.Quantity
+		wantRoundedDown resource.Quantity
 	}{
 		{
-			msg:   "1.01Ki rounded up to nearest 1Ki = 2Ki",
-			input: resource.MustParse("1.01Ki"),
-			unit:  resource.MustParse("1Ki"),
-			want:  resource.MustParse("2Ki"),
+			msg:             "1.5Ki rounded to nearest 1Ki",
+			input:           resource.MustParse("1.5Ki"),
+			unit:            resource.MustParse("1Ki"),
+			wantRoundedUp:   resource.MustParse("2Ki"),
+			wantRoundedDown: resource.MustParse("1Ki"),
 		},
 		{
-			msg:   "64Mi rounded up to nearest 1Mi = no rounding",
-			input: resource.MustParse("64Mi"),
-			unit:  resource.MustParse("1Mi"),
-			want:  resource.MustParse("64Mi"),
+			msg:             "64Mi rounded nearest 1Mi = no rounding",
+			input:           resource.MustParse("64Mi"),
+			unit:            resource.MustParse("1Mi"),
+			wantRoundedUp:   resource.MustParse("64Mi"),
+			wantRoundedDown: resource.MustParse("64Mi"),
 		},
 		{
-			msg:   "64.1Mi rounded up to nearest 1Mi = 65Mi",
-			input: resource.MustParse("64.1Mi"),
-			unit:  resource.MustParse("1Mi"),
-			want:  resource.MustParse("65Mi"),
+			msg:             "64.7Mi rounded to nearest 1Mi",
+			input:           resource.MustParse("64.1Mi"),
+			unit:            resource.MustParse("1Mi"),
+			wantRoundedUp:   resource.MustParse("65Mi"),
+			wantRoundedDown: resource.MustParse("64Mi"),
 		},
 		{
-			msg:   "990Mi rounded up to nearest 1Gi = 1Gi",
-			input: resource.MustParse("990Mi"),
-			unit:  resource.MustParse("1Gi"),
-			want:  resource.MustParse("1Gi"),
+			msg:             "990Mi rounded to nearest 1Gi",
+			input:           resource.MustParse("990Mi"),
+			unit:            resource.MustParse("1Gi"),
+			wantRoundedUp:   resource.MustParse("1Gi"),
+			wantRoundedDown: resource.MustParse("0Gi"),
 		},
 	}
 
 	for _, test := range tests {
-		result := roundUp(test.input, test.unit)
-		assert.True(t, test.want.Equal(result), test.msg)
+		result := round(test.input, test.unit, inf.RoundUp)
+		assert.True(t, test.wantRoundedUp.Equal(result), test.msg+", RoundUp")
+
+		result = round(test.input, test.unit, inf.RoundDown)
+		assert.True(t, test.wantRoundedDown.Equal(result), test.msg+", RoundDown")
 	}
 }


### PR DESCRIPTION
Currently if LimitRange config has MaxLimitRequestRatio set, hedgetrimmer will round up the calculated limit which results in a Limit/Request ratio slightly above the Max. This produces an error both in hedgetrimmer and LimitRanger validation.

To keep the rounding for readability and to be below MaxLimitRequestRatio, use RoundDown on Limit calculation.
The unit test update in `podtemplatespec_test.go` `TestMutate` will catch this issue from now on.

The deployment.yaml change is just a minor addition to exclude `kube-system` namespace.

### Testing
`minikube start`, `make tunnel`, `skaffold dev`

`kubectl edit limitrange limit-resources`, add maxLimitRequestRatio to spec:
```diff
spec:
  limits:
  - defaultRequest:
      cpu: 70m
      memory: 64Mi
+    maxLimitRequestRatio:
+      memory: 1.1
    type: Container
```

Apply the following:
```
apiVersion: v1
kind: Pod
metadata:
  name: test-pod
  namespace: devops
spec:
  containers:
  - name: nginx
    image: "nginx:1.14.2"
    ports:
    - containerPort: 80
    resources:
      requests:
        memory: "1Gi"
```
Notice pod successfully created, whereas before failing.
`kubectl describe pod test-pod` shows limit at `1126Mi` which is rounded down from 1Gi*1.1 = 1126.4Mi.