### PR TITLE
Add logging, some cleanup

### DIFF
--- a/examples/k8s/deployment.yaml
+++ b/examples/k8s/deployment.yaml
@@ -13,8 +13,8 @@ metadata:
 spec:
   secretName: hedgetrimmer
   dnsNames:
-    - hedgetrimmer.devops.svc
-    - hedgetrimmer.devops.svc.cluster.local
+    - hedgetrimmer.hedgetrimmer.svc
+    - hedgetrimmer.hedgetrimmer.svc.cluster.local
   issuerRef:
     name: hedgetrimmer-selfsigned
 
@@ -41,6 +41,11 @@ spec:
           args:
             - "--log-level=debug"
           imagePullPolicy: Always
+          resources:
+            requests:
+              memory: 20Mi
+            limits:
+              memory: 20Mi
           volumeMounts:
             - name: webhook-certs
               mountPath: /etc/webhook/certs
@@ -106,7 +111,7 @@ metadata:
   creationTimestamp: null
   name: hedgetrimmer
   annotations:
-    cert-manager.io/inject-ca-from: devops/hedgetrimmer
+    cert-manager.io/inject-ca-from: hedgetrimmer/hedgetrimmer
 webhooks:
 - clientConfig:
     caBundle: Cg==
@@ -114,7 +119,7 @@ webhooks:
       name: hedgetrimmer
       path: /mutate
       port: 8443
-      namespace: "devops"
+      namespace: "hedgetrimmer"
   sideEffects: None
   admissionReviewVersions: ["v1", "v1beta1"]
   failurePolicy: Ignore

--- a/examples/k8s/rolebindings.yaml
+++ b/examples/k8s/rolebindings.yaml
@@ -59,13 +59,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: hedgetrimmer
-  namespace: devops
+  namespace: hedgetrimmer
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: hedgetrimmer
-  namespace: devops
+  namespace: hedgetrimmer
 rules:
 - apiGroups:
   - ""
@@ -90,7 +90,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: hedgetrimmer
-  namespace: devops
+  namespace: hedgetrimmer
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -98,4 +98,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: hedgetrimmer
-  namespace: devops
+  namespace: hedgetrimmer

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/zap"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -25,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	klog "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	k8szap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
@@ -79,7 +80,12 @@ func (c *RootCommand) persistentPreRunE(cmd *cobra.Command, args []string) error
 		return err
 	}
 
-	klog.SetLogger(zap.New(zap.Level(logLevel)))
+	klog.SetLogger(k8szap.New(
+		k8szap.Level(logLevel),
+		k8szap.RawZapOpts(
+			zap.Fields(zap.Bool("dry-run", viper.GetBool("dry-run"))),
+		)),
+	)
 
 	return nil
 }

--- a/pkg/mutators/podtemplatespec.go
+++ b/pkg/mutators/podtemplatespec.go
@@ -125,11 +125,7 @@ func (p *PodTemplateSpec) setMemoryRequest(ctx context.Context, container *corev
 	}
 
 	if !calculatedRequest.IsZero() {
-		if p.dryRun {
-			log.Info(fmt.Sprintf("[dry-run] setting memory request to %s", calculatedRequest.String()))
-		} else {
-			log.Info(fmt.Sprintf("setting memory request to %s", calculatedRequest.String()))
-		}
+		log.Info(fmt.Sprintf("setting memory request to %s", calculatedRequest.String()))
 		container.Resources.Requests[corev1.ResourceMemory] = calculatedRequest
 	}
 }
@@ -157,11 +153,7 @@ func (p *PodTemplateSpec) setMemoryLimit(ctx context.Context, container *corev1.
 	}
 
 	if !calculatedLimit.IsZero() {
-		if p.dryRun {
-			log.Info(fmt.Sprintf("[dry-run] setting memory limit to %s", calculatedLimit.String()))
-		} else {
-			log.Info(fmt.Sprintf("setting memory limit to %s", calculatedLimit.String()))
-		}
+		log.Info(fmt.Sprintf("setting memory limit to %s", calculatedLimit.String()))
 		container.Resources.Limits[corev1.ResourceMemory] = calculatedLimit
 	}
 }

--- a/pkg/mutators/podtemplatespec.go
+++ b/pkg/mutators/podtemplatespec.go
@@ -127,6 +127,8 @@ func (p *PodTemplateSpec) setMemoryRequest(ctx context.Context, container *corev
 	if !calculatedRequest.IsZero() {
 		if p.dryRun {
 			log.Info(fmt.Sprintf("[dry-run] setting memory request to %s", calculatedRequest.String()))
+		} else {
+			log.Info(fmt.Sprintf("setting memory request to %s", calculatedRequest.String()))
 		}
 		container.Resources.Requests[corev1.ResourceMemory] = calculatedRequest
 	}
@@ -157,6 +159,8 @@ func (p *PodTemplateSpec) setMemoryLimit(ctx context.Context, container *corev1.
 	if !calculatedLimit.IsZero() {
 		if p.dryRun {
 			log.Info(fmt.Sprintf("[dry-run] setting memory limit to %s", calculatedLimit.String()))
+		} else {
+			log.Info(fmt.Sprintf("setting memory limit to %s", calculatedLimit.String()))
 		}
 		container.Resources.Limits[corev1.ResourceMemory] = calculatedLimit
 	}

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -12,6 +12,6 @@ build:
 deploy:
   kubeContext: minikube
   kubectl:
-    defaultNamespace: devops
+    defaultNamespace: hedgetrimmer
     manifests:
       - examples/k8s/*.yaml


### PR DESCRIPTION
Currently when a workload is mutated by hedgetrimmer, the logs do not indicate the mutation, nor which workload was mutated. This will be hard to debug user issues.
```
[hedgetrimmer] {"level":"debug","ts":1668439108.3992758,"logger":"controller-runtime.webhook.webhooks","msg":"received request","webhook":"/mutate","UID":"7a4c90b3-9f47-42af-9e79-2b62df52c408","kind":"/v1, Kind=Pod","resource":{"group":"","version":"v1","resource":"pods"}}
[hedgetrimmer] {"level":"debug","ts":1668439108.4056442,"logger":"controller-runtime.webhook.webhooks","msg":"wrote response","webhook":"/mutate","code":200,"reason":"","UID":"7a4c90b3-9f47-42af-9e79-2b62df52c408","allowed":true}
```

Adds "dry-run" as a field in all logs
```
[hedgetrimmer] {"level":"info","ts":1668446019.9043307,"msg":"setting memory request to 64Mi","dry-run":false,"resource":{"group":"apps","version":"v1","resource":"deployments"},"namespace":"devops","name":"test-deployment","operation":"CREATE"}
[hedgetrimmer] {"level":"info","ts":1668446019.904406,"msg":"setting memory limit to 70Mi","dry-run":false,"resource":{"group":"apps","version":"v1","resource":"deployments"},"namespace":"devops","name":"test-deployment","operation":"CREATE"}
```

Other changes:
- use `hedgetrimmer` namespace
- add memory request and limit for hedgetrimmer deployment because when testing with a LimitRange with MaxLimitRequestRatio set, hedgetrimmer will not deploy unless these are set.