### PR TITLE
Update cert-manager manifest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN go mod download
 COPY . .
 RUN go build -ldflags="-X 'github.com/kanopy-platform/hedgetrimmer/internal/version.version=${VERSION}' -X 'github.com/kanopy-platform/hedgetrimmer/internal/version.gitCommit=${GIT_COMMIT}'" -o /go/bin/app
 
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 RUN apt-get update && apt-get install --yes ca-certificates
 RUN groupadd -r app && useradd --no-log-init -r -g app app
 USER app

--- a/examples/k8s/deployment.yaml
+++ b/examples/k8s/deployment.yaml
@@ -1,12 +1,12 @@
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: hedgetrimmer-selfsigned
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: hedgetrimmer


### PR DESCRIPTION
Updating example manifests to `apiVersion: cert-manager.io/v1` because v1alpha is deprecated.